### PR TITLE
feat: configurable embedding model via MEMORY_MCP_MODEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Vector search uses [node-llama-cpp](https://github.com/withcatai/node-llama-cpp)
 
 If they fail to install (e.g. missing build tools), the server still works with FTS5-only search — no manual intervention needed.
 
-The embedding model ([embeddinggemma-300M](https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF), ~328 MB) is downloaded automatically on first use to `~/.node-llama-cpp/models/`.
+The default embedding model ([embeddinggemma-300M](https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF), ~328 MB) is downloaded automatically on first use to `~/.node-llama-cpp/models/`. You can swap it via the `MEMORY_MCP_MODEL` environment variable (see [Environment Variables](#environment-variables)).
 
 ### Windows: Known Issue with Prebuilt Binaries
 
@@ -101,6 +101,7 @@ The host CLI will automatically search these files before answering questions ab
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `MEMORY_MCP_MODEL` | `hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf` | Embedding model. Accepts a HuggingFace URI (`hf:org/repo/file.gguf`) for auto-download, or a local file path (`/path/to/model.gguf`) |
 | `MEMORY_WORKSPACE` | `~/.copilot` | Root directory to scan for memory files |
 | `MEMORY_DB_PATH` | `~/.copilot/memory.db` | Path to SQLite database |
 | `MEMORY_CHUNK_SIZE` | `512` | Chunk size in tokens for markdown splitting (64–4096). Changing triggers automatic index rebuild |

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -5,7 +5,7 @@
  */
 
 const DEFAULT_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
-const ENV_MODEL_PATH = process.env.MEMORY_MCP_MODEL_PATH;
+const ENV_MODEL_PATH = process.env.MEMORY_MCP_MODEL_PATH || undefined;
 
 // Lazy-init state
 let llamaInstance: unknown = null;
@@ -36,6 +36,9 @@ async function ensureContext(): Promise<EmbeddingContext> {
   }
   if (!embeddingModel) {
     const modelPath = ENV_MODEL_PATH ?? await nodeLlamaCpp.resolveModelFile(DEFAULT_MODEL);
+    if (!modelPath.endsWith(".gguf")) {
+      throw new Error(`MEMORY_MCP_MODEL_PATH does not point to a .gguf file: ${modelPath}`);
+    }
     embeddingModel = await (llamaInstance as { loadModel(o: { modelPath: string }): Promise<unknown> }).loadModel({ modelPath });
   }
   if (!embeddingContext) {
@@ -96,8 +99,12 @@ export async function isEmbeddingAvailable(): Promise<boolean> {
   if (embeddingAvailableCache !== null) return embeddingAvailableCache;
   try {
     if (ENV_MODEL_PATH) {
-      const { accessSync } = await import("fs");
-      accessSync(ENV_MODEL_PATH);
+      if (!ENV_MODEL_PATH.endsWith(".gguf")) {
+        embeddingAvailableCache = false;
+        return false;
+      }
+      const { access } = await import("fs/promises");
+      await access(ENV_MODEL_PATH);
     } else {
       const { resolveModelFile } = await import("node-llama-cpp");
       await resolveModelFile(DEFAULT_MODEL);

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -5,7 +5,11 @@
  */
 
 const DEFAULT_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
-const ENV_MODEL_PATH = process.env.MEMORY_MCP_MODEL_PATH || undefined;
+const ENV_MODEL = process.env.MEMORY_MCP_MODEL || undefined;
+
+function isHfUri(s: string): boolean {
+  return s.startsWith("hf:");
+}
 
 // Lazy-init state
 let llamaInstance: unknown = null;
@@ -35,9 +39,15 @@ async function ensureContext(): Promise<EmbeddingContext> {
     llamaInstance = await nodeLlamaCpp.getLlama({ logLevel: nodeLlamaCpp.LlamaLogLevel.error });
   }
   if (!embeddingModel) {
-    const modelPath = ENV_MODEL_PATH ?? await nodeLlamaCpp.resolveModelFile(DEFAULT_MODEL);
-    if (!modelPath.endsWith(".gguf")) {
-      throw new Error(`MEMORY_MCP_MODEL_PATH does not point to a .gguf file: ${modelPath}`);
+    const spec = ENV_MODEL ?? DEFAULT_MODEL;
+    let modelPath: string;
+    if (isHfUri(spec)) {
+      modelPath = await nodeLlamaCpp.resolveModelFile(spec);
+    } else {
+      if (!spec.endsWith(".gguf")) {
+        throw new Error(`MEMORY_MCP_MODEL does not point to a .gguf file: ${spec}`);
+      }
+      modelPath = spec;
     }
     embeddingModel = await (llamaInstance as { loadModel(o: { modelPath: string }): Promise<unknown> }).loadModel({ modelPath });
   }
@@ -98,16 +108,17 @@ export async function isEmbeddingAvailable(): Promise<boolean> {
   if (unavailable) return false;
   if (embeddingAvailableCache !== null) return embeddingAvailableCache;
   try {
-    if (ENV_MODEL_PATH) {
-      if (!ENV_MODEL_PATH.endsWith(".gguf")) {
+    const spec = ENV_MODEL ?? DEFAULT_MODEL;
+    if (isHfUri(spec)) {
+      const { resolveModelFile } = await import("node-llama-cpp");
+      await resolveModelFile(spec);
+    } else {
+      if (!spec.endsWith(".gguf")) {
         embeddingAvailableCache = false;
         return false;
       }
       const { access } = await import("fs/promises");
-      await access(ENV_MODEL_PATH);
-    } else {
-      const { resolveModelFile } = await import("node-llama-cpp");
-      await resolveModelFile(DEFAULT_MODEL);
+      await access(spec);
     }
     embeddingAvailableCache = true;
     return true;

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -1,12 +1,14 @@
 /**
- * Local embedding provider using node-llama-cpp + embeddinggemma-300M.
- * Lazy-loaded: model is only downloaded/loaded on first embedding request.
+ * Local embedding provider using node-llama-cpp.
+ * Model is configurable via MEMORY_MCP_MODEL env var (HF URI or local path).
+ * Defaults to embeddinggemma-300M. Lazy-loaded on first embedding request.
  * Gracefully unavailable if node-llama-cpp is not installed.
  */
 
 const DEFAULT_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
 const ENV_MODEL = process.env.MEMORY_MCP_MODEL || undefined;
 
+/** Check if spec is a HF URI (only hf: scheme supported by node-llama-cpp resolveModelFile). */
 function isHfUri(s: string): boolean {
   return s.startsWith("hf:");
 }

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -5,6 +5,7 @@
  */
 
 const DEFAULT_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
+const ENV_MODEL_PATH = process.env.MEMORY_MCP_MODEL_PATH;
 
 // Lazy-init state
 let llamaInstance: unknown = null;
@@ -34,7 +35,7 @@ async function ensureContext(): Promise<EmbeddingContext> {
     llamaInstance = await nodeLlamaCpp.getLlama({ logLevel: nodeLlamaCpp.LlamaLogLevel.error });
   }
   if (!embeddingModel) {
-    const modelPath = await nodeLlamaCpp.resolveModelFile(DEFAULT_MODEL);
+    const modelPath = ENV_MODEL_PATH ?? await nodeLlamaCpp.resolveModelFile(DEFAULT_MODEL);
     embeddingModel = await (llamaInstance as { loadModel(o: { modelPath: string }): Promise<unknown> }).loadModel({ modelPath });
   }
   if (!embeddingContext) {
@@ -94,8 +95,13 @@ export async function isEmbeddingAvailable(): Promise<boolean> {
   if (unavailable) return false;
   if (embeddingAvailableCache !== null) return embeddingAvailableCache;
   try {
-    const { resolveModelFile } = await import("node-llama-cpp");
-    await resolveModelFile(DEFAULT_MODEL);
+    if (ENV_MODEL_PATH) {
+      const { accessSync } = await import("fs");
+      accessSync(ENV_MODEL_PATH);
+    } else {
+      const { resolveModelFile } = await import("node-llama-cpp");
+      await resolveModelFile(DEFAULT_MODEL);
+    }
     embeddingAvailableCache = true;
     return true;
   } catch {


### PR DESCRIPTION
## Summary

Make the embedding model configurable via a single `MEMORY_MCP_MODEL` environment variable.

## Changes

### New: `MEMORY_MCP_MODEL` env var
- **HF URI** (`hf:org/repo/file.gguf`) → `resolveModelFile()` auto-downloads from HuggingFace
- **Local path** (`/path/to/model.gguf`) → loads directly, with `.gguf` extension validation
- **Unset** → falls back to hardcoded `embeddinggemma-300M` default

### Bug fixes
- Empty string handling: `|| undefined` at declaration to prevent `""` from being treated as a valid path by `??` but falsy by `if()`
- `accessSync` → `fs/promises.access` in async `isEmbeddingAvailable()`
- `.gguf` extension check in both `ensureContext()` and `isEmbeddingAvailable()` for early, clear errors

### Code quality
- `ensureContext()` and `isEmbeddingAvailable()` use identical `spec` → `isHfUri` branching logic
- Updated file header to reflect configurable model (no longer hardcoded to embeddinggemma)
- JSDoc on `isHfUri()` documenting only `hf:` scheme is supported

## Usage

```bash
# HuggingFace auto-download
MEMORY_MCP_MODEL="hf:Qwen/qwen-embedding-GGUF/xxx.gguf"

# Reuse a local model file
MEMORY_MCP_MODEL="/home/user/.node-llama-cpp/models/bge-m3-Q8_0.gguf"

# Default (no env var needed)
# → embeddinggemma-300M-Q8_0.gguf
```

## Breaking
- `MEMORY_MCP_MODEL_PATH` no longer recognized; use `MEMORY_MCP_MODEL`