### PR TITLE
feat: extra directories support + CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ The host CLI will automatically search these files before answering questions ab
 | `MEMORY_TOKEN_MAX` | `4096` | Default max tokens per search response (100–16384). Controls snippet length and result count |
 | `MEMORY_SESSION_DAYS` | `30` | Only index session transcripts from the last N days (0 = index all) |
 | `MEMORY_SESSION_MAX` | `-1` | Max number of sessions to index, newest first (-1 = no limit, 0 = disable session indexing) |
+| `MEMORY_EXTRA_DIRS` | _(none)_ | Comma-separated extra directories to index (e.g. Obsidian vault). Files are stored with `extra:<dirname>/` prefix |
+
+## CLI
+
+A standalone CLI is available for non-MCP integrations (e.g. calling from scripts or other agents):
+
+```bash
+# Search
+memory-mcp-cli search "query" --max-results 10 --min-score 0.1
+
+# Index status
+memory-mcp-cli status
+```
+
+Or run directly: `node dist/cli.js search "query"`
+
+Output is JSON to stdout, suitable for piping into other tools.
 
 ## Uninstall
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "dist/server.js",
   "bin": {
-    "memory-mcp": "dist/setup.js"
+    "memory-mcp": "dist/setup.js",
+    "memory-mcp-cli": "dist/cli.js"
   },
   "files": [
     "dist",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,26 @@ function parseArgs(args: string[]): { command: string; query?: string; opts: Rec
   return { command, query, opts };
 }
 
+function parsePositiveInt(val: string | undefined, name: string): number | undefined {
+  if (!val) return undefined;
+  const n = Number(val);
+  if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+    console.error(`Error: --${name} must be a positive integer, got "${val}"`);
+    process.exit(1);
+  }
+  return n;
+}
+
+function parsePositiveFloat(val: string | undefined, name: string): number | undefined {
+  if (!val) return undefined;
+  const n = Number(val);
+  if (!Number.isFinite(n) || n < 0) {
+    console.error(`Error: --${name} must be a non-negative number, got "${val}"`);
+    process.exit(1);
+  }
+  return n;
+}
+
 async function main(): Promise<void> {
   const { command, query, opts } = parseArgs(process.argv.slice(2));
 
@@ -102,9 +122,9 @@ async function main(): Promise<void> {
       console.error("Error: search requires a query argument");
       process.exit(1);
     }
-    const maxResults = opts["max-results"] ? Number(opts["max-results"]) : 10;
-    const minScore = opts["min-score"] ? Number(opts["min-score"]) : undefined;
-    const tokenMax = opts["token-max"] ? Number(opts["token-max"]) : undefined;
+    const maxResults = parsePositiveInt(opts["max-results"], "max-results") ?? 10;
+    const minScore = parsePositiveFloat(opts["min-score"], "min-score");
+    const tokenMax = parsePositiveInt(opts["token-max"], "token-max");
     const results = await searchMemory(db, query, { maxResults, minScore, tokenMax });
     console.log(JSON.stringify({ results, count: results.length }, null, 2));
   } else if (command === "status") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,8 +83,7 @@ function parsePositiveInt(val: string | undefined, name: string): number | undef
   if (!val) return undefined;
   const n = Number(val);
   if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
-    console.error(`Error: --${name} must be a positive integer, got "${val}"`);
-    process.exit(1);
+    throw new Error(`--${name} must be a positive integer, got "${val}"`);
   }
   return n;
 }
@@ -93,8 +92,7 @@ function parsePositiveFloat(val: string | undefined, name: string): number | und
   if (!val) return undefined;
   const n = Number(val);
   if (!Number.isFinite(n) || n < 0) {
-    console.error(`Error: --${name} must be a non-negative number, got "${val}"`);
-    process.exit(1);
+    throw new Error(`--${name} must be a non-negative number, got "${val}"`);
   }
   return n;
 }
@@ -111,45 +109,44 @@ async function main(): Promise<void> {
   const dbPath = resolveDbPath();
   const db = await openDatabase(dbPath, { chunkSize: resolveChunkSize() });
 
-  // Sync before search
-  const extraDirs = resolveExtraDirs();
-  await syncMemoryFiles(db, workspaceDir, { chunkSize: resolveChunkSize(), extraDirs });
-  // Best-effort embedding sync
-  try { await syncEmbeddings(db); } catch {}
+  try {
+    // Sync before search
+    const extraDirs = resolveExtraDirs();
+    await syncMemoryFiles(db, workspaceDir, { chunkSize: resolveChunkSize(), extraDirs });
+    // Best-effort embedding sync
+    try { await syncEmbeddings(db); } catch {}
 
-  if (command === "search") {
-    if (!query) {
-      console.error("Error: search requires a query argument");
-      process.exit(1);
+    if (command === "search") {
+      if (!query) {
+        throw new Error("search requires a query argument");
+      }
+      const maxResults = parsePositiveInt(opts["max-results"], "max-results") ?? 10;
+      const minScore = parsePositiveFloat(opts["min-score"], "min-score");
+      const tokenMax = parsePositiveInt(opts["token-max"], "token-max");
+      const results = await searchMemory(db, query, { maxResults, minScore, tokenMax });
+      console.log(JSON.stringify({ results, count: results.length }, null, 2));
+    } else if (command === "status") {
+      const fileCount = (db.prepare(`SELECT COUNT(*) as c FROM files`).get() as { c: number }).c;
+      const chunkCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
+      let vecCount = 0;
+      try { vecCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec`).get() as { c: number }).c; } catch {}
+      console.log(JSON.stringify({
+        workspaceDir,
+        dbPath,
+        extraDirs: extraDirs ?? [],
+        files: fileCount,
+        chunks: chunkCount,
+        embeddedChunks: vecCount,
+      }, null, 2));
+    } else {
+      throw new Error(`Unknown command: ${command}`);
     }
-    const maxResults = parsePositiveInt(opts["max-results"], "max-results") ?? 10;
-    const minScore = parsePositiveFloat(opts["min-score"], "min-score");
-    const tokenMax = parsePositiveInt(opts["token-max"], "token-max");
-    const results = await searchMemory(db, query, { maxResults, minScore, tokenMax });
-    console.log(JSON.stringify({ results, count: results.length }, null, 2));
-  } else if (command === "status") {
-    const fileCount = (db.prepare(`SELECT COUNT(*) as c FROM files`).get() as { c: number }).c;
-    const chunkCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
-    let vecCount = 0;
-    try { vecCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec`).get() as { c: number }).c; } catch {}
-    console.log(JSON.stringify({
-      workspaceDir,
-      dbPath,
-      extraDirs: extraDirs ?? [],
-      files: fileCount,
-      chunks: chunkCount,
-      embeddedChunks: vecCount,
-    }, null, 2));
-  } else {
-    console.error(`Unknown command: ${command}`);
-    printUsage();
-    process.exit(1);
+  } finally {
+    db.close();
   }
-
-  db.close();
 }
 
 main().catch((err) => {
-  console.error("memory-mcp CLI error:", err);
+  console.error("memory-mcp CLI error:", err instanceof Error ? err.message : err);
   process.exit(1);
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+/**
+ * CLI entry point for memory-mcp search.
+ * Usage: node cli.js search "query" [--max-results N] [--min-score N]
+ * Outputs JSON to stdout for integration with OpenClaw exec.
+ */
+
+import path from "node:path";
+import { openDatabase } from "./db.js";
+import { syncMemoryFiles, syncEmbeddings } from "./sync.js";
+import { searchMemory } from "./search.js";
+
+const DEFAULT_WORKSPACE = path.join(
+  process.env.HOME ?? process.env.USERPROFILE ?? "~",
+  ".copilot",
+);
+
+function resolveWorkspaceDir(): string {
+  return process.env.MEMORY_WORKSPACE ?? DEFAULT_WORKSPACE;
+}
+
+function resolveDbPath(): string {
+  return process.env.MEMORY_DB_PATH ?? path.join(resolveWorkspaceDir(), "memory.db");
+}
+
+function resolveChunkSize(): number {
+  const val = process.env.MEMORY_CHUNK_SIZE;
+  if (val) {
+    const n = Number(val);
+    if (n >= 64 && n <= 4096) return n;
+  }
+  return 512;
+}
+
+function resolveExtraDirs(): string[] | undefined {
+  const val = process.env.MEMORY_EXTRA_DIRS;
+  if (!val) return undefined;
+  const dirs = val.split(",").map((d) => d.trim()).filter(Boolean).map((d) => path.resolve(d));
+  return dirs.length > 0 ? dirs : undefined;
+}
+
+function printUsage(): void {
+  console.error(`Usage: memory-mcp <command> [options]
+
+Commands:
+  search <query>    Search memory files
+    --max-results N   Max results (default: 10)
+    --min-score N     Minimum relevance score 0-1 (default: 0.01)
+    --token-max N     Max tokens in response (default: 4096)
+
+  status            Show index status
+
+Environment:
+  MEMORY_WORKSPACE    Root directory (default: ~/.copilot)
+  MEMORY_DB_PATH      SQLite database path
+  MEMORY_EXTRA_DIRS   Comma-separated extra directories to index
+  MEMORY_MCP_MODEL    Embedding model (HF URI or local path)
+  MEMORY_CHUNK_SIZE   Chunk size in tokens (default: 512)`);
+}
+
+function parseArgs(args: string[]): { command: string; query?: string; opts: Record<string, string> } {
+  const command = args[0] ?? "";
+  const opts: Record<string, string> = {};
+  let query: string | undefined;
+  let i = 1;
+  while (i < args.length) {
+    const arg = args[i]!;
+    if (arg.startsWith("--") && i + 1 < args.length) {
+      opts[arg.slice(2)] = args[i + 1]!;
+      i += 2;
+    } else if (!query) {
+      query = arg;
+      i++;
+    } else {
+      i++;
+    }
+  }
+  return { command, query, opts };
+}
+
+async function main(): Promise<void> {
+  const { command, query, opts } = parseArgs(process.argv.slice(2));
+
+  if (!command || command === "help" || command === "--help") {
+    printUsage();
+    process.exit(0);
+  }
+
+  const workspaceDir = resolveWorkspaceDir();
+  const dbPath = resolveDbPath();
+  const db = await openDatabase(dbPath, { chunkSize: resolveChunkSize() });
+
+  // Sync before search
+  const extraDirs = resolveExtraDirs();
+  await syncMemoryFiles(db, workspaceDir, { chunkSize: resolveChunkSize(), extraDirs });
+  // Best-effort embedding sync
+  try { await syncEmbeddings(db); } catch {}
+
+  if (command === "search") {
+    if (!query) {
+      console.error("Error: search requires a query argument");
+      process.exit(1);
+    }
+    const maxResults = opts["max-results"] ? Number(opts["max-results"]) : 10;
+    const minScore = opts["min-score"] ? Number(opts["min-score"]) : undefined;
+    const tokenMax = opts["token-max"] ? Number(opts["token-max"]) : undefined;
+    const results = await searchMemory(db, query, { maxResults, minScore, tokenMax });
+    console.log(JSON.stringify({ results, count: results.length }, null, 2));
+  } else if (command === "status") {
+    const fileCount = (db.prepare(`SELECT COUNT(*) as c FROM files`).get() as { c: number }).c;
+    const chunkCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
+    let vecCount = 0;
+    try { vecCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec`).get() as { c: number }).c; } catch {}
+    console.log(JSON.stringify({
+      workspaceDir,
+      dbPath,
+      extraDirs: extraDirs ?? [],
+      files: fileCount,
+      chunks: chunkCount,
+      embeddedChunks: vecCount,
+    }, null, 2));
+  } else {
+    console.error(`Unknown command: ${command}`);
+    printUsage();
+    process.exit(1);
+  }
+
+  db.close();
+}
+
+main().catch((err) => {
+  console.error("memory-mcp CLI error:", err);
+  process.exit(1);
+});

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -38,8 +38,13 @@ export function buildExtraDirAliases(dirs: string[]): Map<string, string> {
     if (!hasCollision) break;
   }
 
+  // Disambiguate any remaining collisions with numeric suffixes
+  const finalSeen = new Map<string, number>();
   for (const entry of aliases) {
-    result.set(entry.dir, entry.segments.join("-"));
+    const base = entry.segments.join("-");
+    const count = finalSeen.get(base) ?? 0;
+    finalSeen.set(base, count + 1);
+    result.set(entry.dir, count === 0 ? base : `${base}-${count}`);
   }
   return result;
 }

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -35,7 +35,7 @@ export function hashText(value: string): string {
 /**
  * Discover all .md files in MEMORY.md, memory.md, and memory/ directory.
  */
-export async function listMemoryFiles(workspaceDir: string): Promise<string[]> {
+export async function listMemoryFiles(workspaceDir: string, extraDirs?: string[]): Promise<string[]> {
   const result: string[] = [];
   const skippedSymlinks: string[] = [];
 
@@ -60,6 +60,18 @@ export async function listMemoryFiles(workspaceDir: string): Promise<string[]> {
       await walkDir(memoryDir, result, skippedSymlinks);
     }
   } catch {}
+
+  // Walk extra directories (e.g. Obsidian vault)
+  if (extraDirs) {
+    for (const dir of extraDirs) {
+      try {
+        const stat = await fs.lstat(dir);
+        if (stat.isDirectory() && !stat.isSymbolicLink()) {
+          await walkDir(dir, result, skippedSymlinks);
+        }
+      } catch {}
+    }
+  }
 
   if (skippedSymlinks.length > 0) {
     console.error(`[memory-mcp] Skipped ${skippedSymlinks.length} symlink(s): ${skippedSymlinks.join(", ")}`);
@@ -99,11 +111,23 @@ async function walkDir(dir: string, files: string[], skippedSymlinks?: string[])
 export async function buildFileEntry(
   absPath: string,
   workspaceDir: string,
+  extraDirs?: string[],
 ): Promise<MemoryFileEntry> {
   const stat = await fs.stat(absPath);
   const content = await fs.readFile(absPath, "utf-8");
+  // For files under extraDirs, compute path relative to their own root
+  let relPath = path.relative(workspaceDir, absPath).replace(/\\/g, "/");
+  if (extraDirs && relPath.startsWith("..")) {
+    for (const dir of extraDirs) {
+      const rel = path.relative(dir, absPath).replace(/\\/g, "/");
+      if (!rel.startsWith("..")) {
+        relPath = `extra:${path.basename(dir)}/${rel}`;
+        break;
+      }
+    }
+  }
   return {
-    path: path.relative(workspaceDir, absPath).replace(/\\/g, "/"),
+    path: relPath,
     absPath,
     mtimeMs: stat.mtimeMs,
     size: stat.size,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -2,6 +2,48 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+/**
+ * Build unique aliases for extra directories.
+ * Uses basename when unique; appends parent segments to disambiguate collisions.
+ * E.g. ["/a/vault", "/b/vault"] → { "/a/vault": "a-vault", "/b/vault": "b-vault" }
+ */
+export function buildExtraDirAliases(dirs: string[]): Map<string, string> {
+  const result = new Map<string, string>();
+  if (dirs.length === 0) return result;
+
+  // Start with basenames
+  const aliases = dirs.map((d) => ({ dir: d, segments: [path.basename(d)] }));
+
+  // Resolve collisions by prepending parent segments
+  for (let depth = 0; depth < 10; depth++) {
+    const seen = new Map<string, number[]>();
+    for (let i = 0; i < aliases.length; i++) {
+      const key = aliases[i]!.segments.join("-");
+      if (!seen.has(key)) seen.set(key, []);
+      seen.get(key)!.push(i);
+    }
+    let hasCollision = false;
+    for (const [, indices] of seen) {
+      if (indices.length <= 1) continue;
+      hasCollision = true;
+      for (const idx of indices) {
+        const entry = aliases[idx]!;
+        const parts = entry.dir.split(path.sep).filter(Boolean);
+        const currentDepth = entry.segments.length;
+        if (currentDepth < parts.length) {
+          entry.segments.unshift(parts[parts.length - currentDepth - 1]!);
+        }
+      }
+    }
+    if (!hasCollision) break;
+  }
+
+  for (const entry of aliases) {
+    result.set(entry.dir, entry.segments.join("-"));
+  }
+  return result;
+}
+
 /** File extensions indexed by the memory system. */
 export const MEMORY_EXTENSIONS = new Set([".md", ".txt", ".json", ".jsonl", ".yaml", ".yml"]);
 
@@ -111,17 +153,17 @@ async function walkDir(dir: string, files: string[], skippedSymlinks?: string[])
 export async function buildFileEntry(
   absPath: string,
   workspaceDir: string,
-  extraDirs?: string[],
+  extraDirAliases?: Map<string, string>,
 ): Promise<MemoryFileEntry> {
   const stat = await fs.stat(absPath);
   const content = await fs.readFile(absPath, "utf-8");
-  // For files under extraDirs, compute path relative to their own root
+  // For files under extraDirs, compute path relative to their own root with alias prefix
   let relPath = path.relative(workspaceDir, absPath).replace(/\\/g, "/");
-  if (extraDirs && relPath.startsWith("..")) {
-    for (const dir of extraDirs) {
+  if (extraDirAliases && relPath.startsWith("..")) {
+    for (const [dir, alias] of extraDirAliases) {
       const rel = path.relative(dir, absPath).replace(/\\/g, "/");
       if (!rel.startsWith("..")) {
-        relPath = `extra:${path.basename(dir)}/${rel}`;
+        relPath = `extra:${alias}/${rel}`;
         break;
       }
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -179,9 +179,19 @@ server.tool(
         : path.resolve(workspaceDir, relPath);
     }
 
-    // Security: allow workspace memory paths + extraDirs paths
+    // Security: resolve symlinks before checking path containment
+    let realPath: string;
+    try {
+      realPath = fs.realpathSync(absPath);
+    } catch {
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify({ error: "file not found" }) }],
+        isError: true,
+      };
+    }
+
     let allowed = false;
-    const rel = path.relative(workspaceDir, absPath).replace(/\\/g, "/");
+    const rel = path.relative(workspaceDir, realPath).replace(/\\/g, "/");
     if (
       rel === "MEMORY.md" ||
       rel === "memory.md" ||
@@ -189,18 +199,20 @@ server.tool(
       rel === "memory.txt" ||
       rel.startsWith("memory/")
     ) {
-      allowed = true;
+      // Ensure it doesn't escape via ../ after the prefix
+      if (!rel.includes("..")) allowed = true;
     }
     if (!allowed && extraDirs) {
       for (const dir of extraDirs) {
-        const extraRel = path.relative(dir, absPath).replace(/\\/g, "/");
-        if (!extraRel.startsWith("..")) {
+        const realDir = fs.realpathSync(dir);
+        const extraRel = path.relative(realDir, realPath).replace(/\\/g, "/");
+        if (!extraRel.startsWith("..") && !path.isAbsolute(extraRel)) {
           allowed = true;
           break;
         }
       }
     }
-    if (!allowed || !MEMORY_EXTENSIONS.has(path.extname(absPath).toLowerCase())) {
+    if (!allowed || !MEMORY_EXTENSIONS.has(path.extname(realPath).toLowerCase())) {
       return {
         content: [{ type: "text" as const, text: JSON.stringify({ error: "path not allowed" }) }],
         isError: true,
@@ -208,7 +220,7 @@ server.tool(
     }
 
     try {
-      const content = fs.readFileSync(absPath, "utf-8");
+      const content = fs.readFileSync(realPath, "utf-8");
       if (!from && !lines) {
         return {
           content: [{ type: "text" as const, text: JSON.stringify({ path: rel, text: content }) }],

--- a/src/server.ts
+++ b/src/server.ts
@@ -204,7 +204,8 @@ server.tool(
     }
     if (!allowed && extraDirs) {
       for (const dir of extraDirs) {
-        const realDir = fs.realpathSync(dir);
+        let realDir: string;
+        try { realDir = fs.realpathSync(dir); } catch { continue; }
         const extraRel = path.relative(realDir, realPath).replace(/\\/g, "/");
         if (!extraRel.startsWith("..") && !path.isAbsolute(extraRel)) {
           allowed = true;

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,6 +59,13 @@ function resolveSessionMax(): number {
   return -1; // no count limit
 }
 
+function resolveExtraDirs(): string[] | undefined {
+  const val = process.env.MEMORY_EXTRA_DIRS;
+  if (!val) return undefined;
+  const dirs = val.split(",").map((d) => d.trim()).filter(Boolean).map((d) => path.resolve(d));
+  return dirs.length > 0 ? dirs : undefined;
+}
+
 const server = new McpServer({
   name: "memory",
   version: "0.1.0",
@@ -82,7 +89,7 @@ async function ensureSynced(): Promise<void> {
   const workspaceDir = resolveWorkspaceDir();
   try {
     if (memoryDue) {
-      await syncMemoryFiles(db, workspaceDir, { chunkSize: resolveChunkSize() });
+      await syncMemoryFiles(db, workspaceDir, { chunkSize: resolveChunkSize(), extraDirs: resolveExtraDirs() });
       lastSyncAt = Date.now();
     }
     if (sessionDue) {
@@ -141,18 +148,50 @@ server.tool(
   },
   async ({ path: relPath, from, lines }) => {
     const workspaceDir = resolveWorkspaceDir();
-    const absPath = path.isAbsolute(relPath)
-      ? path.resolve(relPath)
-      : path.resolve(workspaceDir, relPath);
+    const extraDirs = resolveExtraDirs();
 
-    // Security: only allow memory paths
+    // Resolve extra: prefix paths (e.g. extra:ObsidianVault/notes/foo.md)
+    let absPath: string;
+    if (relPath.startsWith("extra:") && extraDirs) {
+      const rest = relPath.slice("extra:".length); // e.g. ObsidianVault/notes/foo.md
+      const dirName = rest.split("/")[0]!;
+      const matched = extraDirs.find((d) => path.basename(d) === dirName);
+      if (matched) {
+        const subPath = rest.slice(dirName.length + 1);
+        absPath = path.resolve(matched, subPath);
+      } else {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ error: "path not allowed" }) }],
+          isError: true,
+        };
+      }
+    } else {
+      absPath = path.isAbsolute(relPath)
+        ? path.resolve(relPath)
+        : path.resolve(workspaceDir, relPath);
+    }
+
+    // Security: allow workspace memory paths + extraDirs paths
+    let allowed = false;
     const rel = path.relative(workspaceDir, absPath).replace(/\\/g, "/");
-    const allowed =
+    if (
       rel === "MEMORY.md" ||
       rel === "memory.md" ||
       rel === "MEMORY.txt" ||
       rel === "memory.txt" ||
-      rel.startsWith("memory/");
+      rel.startsWith("memory/")
+    ) {
+      allowed = true;
+    }
+    if (!allowed && extraDirs) {
+      for (const dir of extraDirs) {
+        const extraRel = path.relative(dir, absPath).replace(/\\/g, "/");
+        if (!extraRel.startsWith("..")) {
+          allowed = true;
+          break;
+        }
+      }
+    }
     if (!allowed || !MEMORY_EXTENSIONS.has(path.extname(absPath).toLowerCase())) {
       return {
         content: [{ type: "text" as const, text: JSON.stringify({ error: "path not allowed" }) }],

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import fs from "node:fs";
 import { openDatabase } from "./db.js";
 import { syncMemoryFiles, syncSessionFiles, syncEmbeddings } from "./sync.js";
 import { searchMemory } from "./search.js";
-import { MEMORY_EXTENSIONS, hashText } from "./internal.js";
+import { MEMORY_EXTENSIONS, hashText, buildExtraDirAliases } from "./internal.js";
 
 const DEFAULT_WORKSPACE = path.join(
   process.env.HOME ?? process.env.USERPROFILE ?? "~",
@@ -150,14 +150,22 @@ server.tool(
     const workspaceDir = resolveWorkspaceDir();
     const extraDirs = resolveExtraDirs();
 
-    // Resolve extra: prefix paths (e.g. extra:ObsidianVault/notes/foo.md)
+    // Resolve extra: prefix paths using alias → directory mapping
     let absPath: string;
     if (relPath.startsWith("extra:") && extraDirs) {
-      const rest = relPath.slice("extra:".length); // e.g. ObsidianVault/notes/foo.md
-      const dirName = rest.split("/")[0]!;
-      const matched = extraDirs.find((d) => path.basename(d) === dirName);
+      const rest = relPath.slice("extra:".length); // e.g. a-vault/notes/foo.md
+      const aliases = buildExtraDirAliases(extraDirs);
+      // Find alias match: try longest alias prefix first
+      let matched: string | undefined;
+      let subPath = "";
+      for (const [dir, alias] of aliases) {
+        if (rest.startsWith(alias + "/")) {
+          matched = dir;
+          subPath = rest.slice(alias.length + 1);
+          break;
+        }
+      }
       if (matched) {
-        const subPath = rest.slice(dirName.length + 1);
         absPath = path.resolve(matched, subPath);
       } else {
         return {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -5,6 +5,7 @@ import {
   listSessionFiles,
   buildFileEntry,
   buildSessionEntry,
+  buildExtraDirAliases,
   chunkFile,
   chunkMarkdown,
   type MemoryFileEntry,
@@ -29,8 +30,9 @@ export async function syncMemoryFiles(
   opts?: { force?: boolean; chunkSize?: number; extraDirs?: string[] },
 ): Promise<SyncResult> {
   const files = await listMemoryFiles(workspaceDir, opts?.extraDirs);
+  const extraDirAliases = opts?.extraDirs ? buildExtraDirAliases(opts.extraDirs) : undefined;
   const entries = await Promise.all(
-    files.map((f) => buildFileEntry(f, workspaceDir, opts?.extraDirs)),
+    files.map((f) => buildFileEntry(f, workspaceDir, extraDirAliases)),
   );
 
   const ftsOk = isFtsAvailable(db);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -26,11 +26,11 @@ export type SyncResult = {
 export async function syncMemoryFiles(
   db: Database.Database,
   workspaceDir: string,
-  opts?: { force?: boolean; chunkSize?: number },
+  opts?: { force?: boolean; chunkSize?: number; extraDirs?: string[] },
 ): Promise<SyncResult> {
-  const files = await listMemoryFiles(workspaceDir);
+  const files = await listMemoryFiles(workspaceDir, opts?.extraDirs);
   const entries = await Promise.all(
-    files.map((f) => buildFileEntry(f, workspaceDir)),
+    files.map((f) => buildFileEntry(f, workspaceDir, opts?.extraDirs)),
   );
 
   const ftsOk = isFtsAvailable(db);


### PR DESCRIPTION
## Summary

Add support for indexing additional directories (e.g. Obsidian vault) alongside the main workspace, and a standalone CLI for non-MCP integrations.

## Motivation

- **Search isolation**: Keep extra content (vault notes) in the same SQLite index but with distinct `extra:<dirname>/` path prefixes, so results are clearly distinguishable from workspace memory files
- **CLI for agents**: OpenClaw on GCP needs to call memory-mcp search via `exec` (no MCP protocol support), so a CLI entry point that outputs JSON to stdout is needed
- **Local Copilot CLI**: `MEMORY_EXTRA_DIRS` lets Copilot CLI users index their Obsidian vault alongside `~/.copilot` memory without changing `MEMORY_WORKSPACE`

## Changes

### Extra directories (`MEMORY_EXTRA_DIRS`)
- **`internal.ts`**: `listMemoryFiles(workspaceDir, extraDirs?)` — walks extra dirs and includes their files
- **`internal.ts`**: `buildFileEntry()` — files under extraDirs get `extra:<dirname>/relative/path` as their stored path (avoids `../../` relative paths)
- **`sync.ts`**: `syncMemoryFiles()` opts gains `extraDirs` — passes through to listing and file entry building
- **`server.ts`**: New `resolveExtraDirs()` reads `MEMORY_EXTRA_DIRS` env (comma-separated); `ensureSynced()` passes it; `memory_get` security check expanded to allow reading extraDirs files via `extra:` prefix resolution

### CLI (`cli.ts`)
- `search <query>` — syncs + searches, outputs JSON to stdout
- `status` — shows index stats (files, chunks, embeddings)
- Registered as `memory-mcp-cli` bin in package.json
- Reads all standard env vars (`MEMORY_WORKSPACE`, `MEMORY_EXTRA_DIRS`, `MEMORY_MCP_MODEL`, etc.)

### Docs
- README: Added `MEMORY_EXTRA_DIRS` to env table + new CLI section

## Usage

```bash
# Index workspace + Obsidian vault
MEMORY_WORKSPACE=~/.copilot \
MEMORY_EXTRA_DIRS=/data/obsidian-vault \
memory-mcp-cli search "TypeScript generics"

# GCP integration via exec
node /path/to/memory-mcp/dist/cli.js search "投资分析框架" --max-results 5
```

## Path format

| File location | Stored path |
|---|---|
| `~/.copilot/MEMORY.md` | `MEMORY.md` |
| `~/.copilot/memory/decisions.md` | `memory/decisions.md` |
| `/data/obsidian-vault/Java/generics.md` | `extra:obsidian-vault/Java/generics.md` |