### PR TITLE
feat: centralized config with persistent config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Vector search uses [node-llama-cpp](https://github.com/withcatai/node-llama-cpp)
 
 If they fail to install (e.g. missing build tools), the server still works with FTS5-only search — no manual intervention needed.
 
-The default embedding model ([embeddinggemma-300M](https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF), ~328 MB) is downloaded automatically on first use to `~/.node-llama-cpp/models/`. You can swap it via the `MEMORY_MCP_MODEL` environment variable (see [Environment Variables](#environment-variables)).
+The default embedding model ([embeddinggemma-300M](https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF), ~328 MB) is downloaded automatically on first use to `~/.node-llama-cpp/models/`. You can swap it via config: `memory-mcp config set model /path/to/model.gguf` (see [Configuration](#configuration)).
 
 ### Windows: Known Issue with Prebuilt Binaries
 
@@ -94,7 +94,8 @@ The host CLI will automatically search these files before answering questions ab
 6. Search runs both FTS5 (BM25 ranking) and vector (cosine similarity) in parallel
 7. Results are **min-max normalized** then merged with 50/50 weighting
 8. Access-count boost gently promotes frequently retrieved chunks
-9. Falls back to LIKE search if FTS5 is unavailable
+9. Top-level `MEMORY.md` results receive a score boost (×1.3) for long-term memory priority
+10. Falls back to LIKE search if FTS5 is unavailable
 
 ## Configuration
 
@@ -144,9 +145,20 @@ memory-mcp-cli search "query" --max-results 10 --min-score 0.1
 memory-mcp-cli status
 ```
 
+All config keys can be temporarily overridden via CLI flags:
+
+```bash
+memory-mcp-cli search "query" --workspace /tmp/alt-memory
+memory-mcp-cli status --chunk-size 1024 --session-days 7
+```
+
 Or run directly: `node dist/cli.js search "query"`
 
 Output is JSON to stdout, suitable for piping into other tools.
+
+## Upgrading
+
+When upgrading from a version that used `~/.copilot/` or `~/.claude/` as the workspace, `memory-mcp setup` (or the MCP server on first start) will automatically copy your memory files to `~/.memory-mcp-workdir/`. Original files are preserved — remove them manually when ready.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The host CLI will automatically search these files before answering questions ab
 All settings have sensible defaults and work out of the box. To customize, use the config command:
 
 ```bash
-# Show current config (merged: env var > config file > defaults)
+# Show current config
 memory-mcp config
 
 # Set a value
@@ -117,22 +117,20 @@ memory-mcp config reset
 memory-mcp config path
 ```
 
-Config is stored in `~/memory-mcp.json`. Environment variables override config file values.
+Config is stored in `~/memory-mcp.json` (cross-platform: `$HOME` on Linux/macOS, `%USERPROFILE%` on Windows).
 
-## Environment Variables
+### Config Keys
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MEMORY_MCP_MODEL` | `hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf` | Embedding model. Accepts a HuggingFace URI (`hf:org/repo/file.gguf`) for auto-download, or a local file path (`/path/to/model.gguf`) |
-| `MEMORY_WORKSPACE` | `~/.copilot` | Root directory to scan for memory files |
-| `MEMORY_DB_PATH` | `~/.copilot/memory.db` | Path to SQLite database |
-| `MEMORY_CHUNK_SIZE` | `512` | Chunk size in tokens for markdown splitting (64–4096). Changing triggers automatic index rebuild |
-| `MEMORY_TOKEN_MAX` | `4096` | Default max tokens per search response (100–16384). Controls snippet length and result count |
-| `MEMORY_SESSION_DAYS` | `30` | Only index session transcripts from the last N days (0 = index all) |
-| `MEMORY_SESSION_MAX` | `-1` | Max number of sessions to index, newest first (-1 = no limit, 0 = disable session indexing) |
-| `MEMORY_EXTRA_DIRS` | _(none)_ | Comma-separated extra directories to index (e.g. Obsidian vault). Files are stored with `extra:<dirname>/` prefix |
-
-**Priority**: environment variable > config file (`~/memory-mcp.json`) > built-in defaults.
+| Key | Default | Description |
+|-----|---------|-------------|
+| `workspace` | `~/.copilot` | Root directory to scan for memory files |
+| `dbPath` | `<workspace>/memory.db` | Path to SQLite database |
+| `chunkSize` | `512` | Chunk size in tokens for markdown splitting (64–4096). Changing triggers automatic index rebuild |
+| `tokenMax` | `4096` | Default max tokens per search response (100–16384). Controls snippet length and result count |
+| `sessionDays` | `30` | Only index session transcripts from the last N days (0 = index all) |
+| `sessionMax` | `-1` | Max number of sessions to index, newest first (-1 = no limit, 0 = disable session indexing) |
+| `extraDirs` | `[]` | Extra directories to index (e.g. Obsidian vault). Files are stored with `extra:<dirname>/` prefix |
+| `model` | `hf:ggml-org/embeddinggemma-300M-GGUF/...` | Embedding model. Accepts a HuggingFace URI (`hf:org/repo/file.gguf`) for auto-download, or a local file path (`/path/to/model.gguf`) |
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ memory-mcp config reset
 memory-mcp config path
 ```
 
-Config is stored in `~/.copilot/memory-mcp.json`. Environment variables override config file values.
+Config is stored in `~/memory-mcp.json`. Environment variables override config file values.
 
 ## Environment Variables
 
@@ -132,7 +132,7 @@ Config is stored in `~/.copilot/memory-mcp.json`. Environment variables override
 | `MEMORY_SESSION_MAX` | `-1` | Max number of sessions to index, newest first (-1 = no limit, 0 = disable session indexing) |
 | `MEMORY_EXTRA_DIRS` | _(none)_ | Comma-separated extra directories to index (e.g. Obsidian vault). Files are stored with `extra:<dirname>/` prefix |
 
-**Priority**: environment variable > config file (`~/.copilot/memory-mcp.json`) > built-in defaults.
+**Priority**: environment variable > config file (`~/memory-mcp.json`) > built-in defaults.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,28 @@ The host CLI will automatically search these files before answering questions ab
 8. Access-count boost gently promotes frequently retrieved chunks
 9. Falls back to LIKE search if FTS5 is unavailable
 
+## Configuration
+
+All settings have sensible defaults and work out of the box. To customize, use the config command:
+
+```bash
+# Show current config (merged: env var > config file > defaults)
+memory-mcp config
+
+# Set a value
+memory-mcp config set chunkSize 1024
+memory-mcp config set extraDirs /data/obsidian-vault,/data/notes
+memory-mcp config set model /path/to/local-model.gguf
+
+# Reset to defaults
+memory-mcp config reset
+
+# Show config file path
+memory-mcp config path
+```
+
+Config is stored in `~/.copilot/memory-mcp.json`. Environment variables override config file values.
+
 ## Environment Variables
 
 | Variable | Default | Description |
@@ -109,6 +131,8 @@ The host CLI will automatically search these files before answering questions ab
 | `MEMORY_SESSION_DAYS` | `30` | Only index session transcripts from the last N days (0 = index all) |
 | `MEMORY_SESSION_MAX` | `-1` | Max number of sessions to index, newest first (-1 = no limit, 0 = disable session indexing) |
 | `MEMORY_EXTRA_DIRS` | _(none)_ | Comma-separated extra directories to index (e.g. Obsidian vault). Files are stored with `extra:<dirname>/` prefix |
+
+**Priority**: environment variable > config file (`~/.copilot/memory-mcp.json`) > built-in defaults.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,12 @@ This compiles with the correct Windows API path and restores full multi-threaded
 
 ## Usage
 
-Memory files live in a dot-directory under your home folder:
-
-- **Copilot CLI**: `~/.copilot/` (default)
-- **Claude Code**: `~/.claude/` (when using `--claude`)
+All memory data lives in a single shared directory, used by both Copilot CLI and Claude Code:
 
 ```
-~/.copilot/  (or ~/.claude/)
+~/.memory-mcp-workdir/
+├── memory-mcp.json        # Configuration file
+├── memory.db              # SQLite database (index + vectors)
 ├── MEMORY.md              # Top-level memory file
 └── memory/
     ├── decisions.md       # Architecture decisions
@@ -117,18 +116,19 @@ memory-mcp config reset
 memory-mcp config path
 ```
 
-Config is stored in `~/memory-mcp.json` (cross-platform: `$HOME` on Linux/macOS, `%USERPROFILE%` on Windows).
+Config is stored in `~/.memory-mcp-workdir/memory-mcp.json` (cross-platform: `$HOME` on Linux/macOS, `%USERPROFILE%` on Windows).
 
 ### Config Keys
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `workspace` | `~/.copilot` | Root directory to scan for memory files |
+| `workspace` | `~/.memory-mcp-workdir` | Root directory for memory files and database |
 | `dbPath` | `<workspace>/memory.db` | Path to SQLite database |
 | `chunkSize` | `512` | Chunk size in tokens for markdown splitting (64–4096). Changing triggers automatic index rebuild |
 | `tokenMax` | `4096` | Default max tokens per search response (100–16384). Controls snippet length and result count |
 | `sessionDays` | `30` | Only index session transcripts from the last N days (0 = index all) |
 | `sessionMax` | `-1` | Max number of sessions to index, newest first (-1 = no limit, 0 = disable session indexing) |
+| `sessionDirs` | `[copilot, claude]` | Session transcript sources. Default: `~/.copilot/session-state` (copilot) + `~/.claude/projects` (claude). Set to override entirely. JSON format: `[{"dir":"/path","kind":"copilot"}]` |
 | `extraDirs` | `[]` | Extra directories to index (e.g. Obsidian vault). Files are stored with `extra:<dirname>/` prefix |
 | `model` | `hf:ggml-org/embeddinggemma-300M-GGUF/...` | Embedding model. Accepts a HuggingFace URI (`hf:org/repo/file.gguf`) for auto-download, or a local file path (`/path/to/model.gguf`) |
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ memory-mcp config reset
 memory-mcp config path
 ```
 
-Config is stored in `~/.memory-mcp-workdir/memory-mcp.json` (cross-platform: `$HOME` on Linux/macOS, `%USERPROFILE%` on Windows).
+Config is stored in `~/.memory-mcp-workdir/memory-mcp.json` (cross-platform: `$HOME` on Linux/macOS, `%USERPROFILE%` on Windows). Changes take effect on next server restart.
 
 ### Config Keys
 
@@ -159,6 +159,8 @@ Output is JSON to stdout, suitable for piping into other tools.
 ## Upgrading
 
 When upgrading from a version that used `~/.copilot/` or `~/.claude/` as the workspace, `memory-mcp setup` (or the MCP server on first start) will automatically copy your memory files to `~/.memory-mcp-workdir/`. Original files are preserved — remove them manually when ready.
+
+**Breaking change:** All `MEMORY_*` environment variables have been removed. Configuration is now managed entirely through the config file (`~/.memory-mcp-workdir/memory-mcp.json`). Use `memory-mcp config set <key> <value>` to migrate your settings.
 
 ## Uninstall
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,8 +35,10 @@ Global flags (override config for this run):
   --model <path>        Override embedding model
 
 Configuration:
-  All settings are read from ~/.memory-mcp-workdir/memory-mcp.json (editable via "memory-mcp config set").
-  Run "memory-mcp config" to view current settings.`);
+  All settings are read from ~/.memory-mcp-workdir/memory-mcp.json.
+  Config is managed via the "memory-mcp" command (not memory-mcp-cli):
+    memory-mcp config            Show current settings
+    memory-mcp config set <k> <v> Set a value`);
 }
 
 function parseArgs(args: string[]): { command: string; query?: string; opts: Record<string, string> } {
@@ -59,7 +61,7 @@ function parseArgs(args: string[]): { command: string; query?: string; opts: Rec
   return { command, query, opts };
 }
 
-function parsePositiveInt(val: string | undefined, name: string): number | undefined {
+function parseNonNegativeInt(val: string | undefined, name: string): number | undefined {
   if (!val) return undefined;
   const n = Number(val);
   if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
@@ -153,9 +155,9 @@ async function main(): Promise<void> {
       if (!query) {
         throw new Error("search requires a query argument");
       }
-      const maxResults = parsePositiveInt(rest["max-results"], "max-results") ?? 10;
+      const maxResults = parseNonNegativeInt(rest["max-results"], "max-results") ?? 10;
       const minScore = parsePositiveFloat(rest["min-score"], "min-score");
-      const tokenMax = parsePositiveInt(rest["token-max"], "token-max") ?? config.tokenMax;
+      const tokenMax = parseNonNegativeInt(rest["token-max"], "token-max") ?? config.tokenMax;
       const results = await searchMemory(db, query, { maxResults, minScore, tokenMax });
       console.log(JSON.stringify({ results, count: results.length }, null, 2));
     } else if (command === "status") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,10 +6,11 @@
  * Outputs JSON to stdout for integration with OpenClaw exec.
  */
 
+import path from "node:path";
 import { openDatabase } from "./db.js";
-import { syncMemoryFiles, syncEmbeddings } from "./sync.js";
+import { syncMemoryFiles, syncSessionFiles, syncEmbeddings } from "./sync.js";
 import { searchMemory } from "./search.js";
-import { loadConfig, resolvedExtraDirs } from "./config.js";
+import { loadConfig, resolvedExtraDirs, type MemoryConfigFile } from "./config.js";
 
 function printUsage(): void {
   console.error(`Usage: memory-mcp-cli <command> [options]
@@ -22,8 +23,19 @@ Commands:
 
   status            Show index status
 
+Global flags (override config for this run):
+  --config <path>       Use a custom config file
+  --workspace <path>    Override workspace directory
+  --db-path <path>      Override database path
+  --chunk-size N        Override chunk size
+  --session-days N      Override session days
+  --session-max N       Override session max
+  --session-dirs <json> Override session dirs (JSON array)
+  --extra-dirs <paths>  Override extra dirs (comma-separated)
+  --model <path>        Override embedding model
+
 Configuration:
-  All settings are read from ~/memory-mcp.json (editable via "memory-mcp config set").
+  All settings are read from ~/.memory-mcp-workdir/memory-mcp.json (editable via "memory-mcp config set").
   Run "memory-mcp config" to view current settings.`);
 }
 
@@ -65,6 +77,50 @@ function parsePositiveFloat(val: string | undefined, name: string): number | und
   return n;
 }
 
+/** Global config flags (kebab-case). Extracted before command-specific parsing. */
+const GLOBAL_FLAGS = new Set([
+  "config", "workspace", "db-path", "chunk-size", "token-max",
+  "session-days", "session-max", "session-dirs", "extra-dirs", "model",
+]);
+
+/** Extract global config overrides from opts, returning {overrides, configPath, rest}. */
+function extractGlobalOverrides(opts: Record<string, string>): {
+  overrides: MemoryConfigFile;
+  configPath?: string;
+  rest: Record<string, string>;
+} {
+  const overrides: MemoryConfigFile = {};
+  let configPath: string | undefined;
+  const rest: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(opts)) {
+    if (!GLOBAL_FLAGS.has(key)) {
+      rest[key] = value;
+      continue;
+    }
+    switch (key) {
+      case "config": configPath = value; break;
+      case "workspace": overrides.workspace = path.resolve(value); break;
+      case "db-path": overrides.dbPath = path.resolve(value); break;
+      case "chunk-size": overrides.chunkSize = Number(value); break;
+      case "token-max": overrides.tokenMax = Number(value); break;
+      case "session-days": overrides.sessionDays = Number(value); break;
+      case "session-max": overrides.sessionMax = Number(value); break;
+      case "session-dirs":
+        try { overrides.sessionDirs = JSON.parse(value); } catch {
+          throw new Error(`--session-dirs must be valid JSON, got "${value}"`);
+        }
+        break;
+      case "extra-dirs":
+        overrides.extraDirs = value.split(",").map((d) => d.trim()).filter(Boolean).map((d) => path.resolve(d));
+        break;
+      case "model": overrides.model = value; break;
+    }
+  }
+
+  return { overrides, configPath, rest };
+}
+
 async function main(): Promise<void> {
   const { command, query, opts } = parseArgs(process.argv.slice(2));
 
@@ -73,7 +129,9 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  const config = loadConfig();
+  const { overrides, configPath, rest } = extractGlobalOverrides(opts);
+  const hasOverrides = Object.keys(overrides).length > 0 || configPath;
+  const config = hasOverrides ? loadConfig(overrides, configPath) : loadConfig();
   const workspaceDir = config.workspace;
   const dbPath = config.dbPath;
   const db = await openDatabase(dbPath, { chunkSize: config.chunkSize });
@@ -82,6 +140,12 @@ async function main(): Promise<void> {
     // Sync before search
     const extraDirs = resolvedExtraDirs(config);
     await syncMemoryFiles(db, workspaceDir, { chunkSize: config.chunkSize, extraDirs });
+    await syncSessionFiles(db, {
+      chunkSize: config.chunkSize,
+      maxDays: config.sessionDays,
+      maxCount: config.sessionMax,
+      sessionDirs: config.sessionDirs,
+    });
     // Best-effort embedding sync
     try { await syncEmbeddings(db); } catch {}
 
@@ -89,23 +153,36 @@ async function main(): Promise<void> {
       if (!query) {
         throw new Error("search requires a query argument");
       }
-      const maxResults = parsePositiveInt(opts["max-results"], "max-results") ?? 10;
-      const minScore = parsePositiveFloat(opts["min-score"], "min-score");
-      const tokenMax = parsePositiveInt(opts["token-max"], "token-max");
+      const maxResults = parsePositiveInt(rest["max-results"], "max-results") ?? 10;
+      const minScore = parsePositiveFloat(rest["min-score"], "min-score");
+      const tokenMax = parsePositiveInt(rest["token-max"], "token-max") ?? config.tokenMax;
       const results = await searchMemory(db, query, { maxResults, minScore, tokenMax });
       console.log(JSON.stringify({ results, count: results.length }, null, 2));
     } else if (command === "status") {
       const fileCount = (db.prepare(`SELECT COUNT(*) as c FROM files`).get() as { c: number }).c;
+      const memoryFileCount = (db.prepare(`SELECT COUNT(*) as c FROM files WHERE source = 'memory'`).get() as { c: number }).c;
+      const sessionFileCount = (db.prepare(`SELECT COUNT(*) as c FROM files WHERE source = 'sessions'`).get() as { c: number }).c;
       const chunkCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
       let vecCount = 0;
       try { vecCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec`).get() as { c: number }).c; } catch {}
+      let cacheCount = 0;
+      try { cacheCount = (db.prepare(`SELECT COUNT(*) as c FROM embedding_cache`).get() as { c: number }).c; } catch {}
       console.log(JSON.stringify({
         workspaceDir,
         dbPath,
         extraDirs: extraDirs ?? [],
         files: fileCount,
+        memoryFiles: memoryFileCount,
+        sessionFiles: sessionFileCount,
         chunks: chunkCount,
         embeddedChunks: vecCount,
+        embeddingCache: cacheCount,
+        config: {
+          chunkSize: config.chunkSize,
+          tokenMax: config.tokenMax,
+          sessionDays: config.sessionDays,
+          sessionMax: config.sessionMax,
+        },
       }, null, 2));
     } else {
       throw new Error(`Unknown command: ${command}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,13 +23,8 @@ Commands:
   status            Show index status
 
 Configuration:
-  Settings are read from ~/memory-mcp.json (editable via "memory-mcp config set").
-  Environment variables override config file values:
-    MEMORY_WORKSPACE    Root directory (default: ~/.copilot)
-    MEMORY_DB_PATH      SQLite database path
-    MEMORY_EXTRA_DIRS   Comma-separated extra directories to index
-    MEMORY_MCP_MODEL    Embedding model (HF URI or local path)
-    MEMORY_CHUNK_SIZE   Chunk size in tokens (default: 512)`);
+  All settings are read from ~/memory-mcp.json (editable via "memory-mcp config set").
+  Run "memory-mcp config" to view current settings.`);
 }
 
 function parseArgs(args: string[]): { command: string; query?: string; opts: Record<string, string> } {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,42 +6,13 @@
  * Outputs JSON to stdout for integration with OpenClaw exec.
  */
 
-import path from "node:path";
 import { openDatabase } from "./db.js";
 import { syncMemoryFiles, syncEmbeddings } from "./sync.js";
 import { searchMemory } from "./search.js";
-
-const DEFAULT_WORKSPACE = path.join(
-  process.env.HOME ?? process.env.USERPROFILE ?? "~",
-  ".copilot",
-);
-
-function resolveWorkspaceDir(): string {
-  return process.env.MEMORY_WORKSPACE ?? DEFAULT_WORKSPACE;
-}
-
-function resolveDbPath(): string {
-  return process.env.MEMORY_DB_PATH ?? path.join(resolveWorkspaceDir(), "memory.db");
-}
-
-function resolveChunkSize(): number {
-  const val = process.env.MEMORY_CHUNK_SIZE;
-  if (val) {
-    const n = Number(val);
-    if (n >= 64 && n <= 4096) return n;
-  }
-  return 512;
-}
-
-function resolveExtraDirs(): string[] | undefined {
-  const val = process.env.MEMORY_EXTRA_DIRS;
-  if (!val) return undefined;
-  const dirs = val.split(",").map((d) => d.trim()).filter(Boolean).map((d) => path.resolve(d));
-  return dirs.length > 0 ? dirs : undefined;
-}
+import { loadConfig, resolvedExtraDirs } from "./config.js";
 
 function printUsage(): void {
-  console.error(`Usage: memory-mcp <command> [options]
+  console.error(`Usage: memory-mcp-cli <command> [options]
 
 Commands:
   search <query>    Search memory files
@@ -51,12 +22,14 @@ Commands:
 
   status            Show index status
 
-Environment:
-  MEMORY_WORKSPACE    Root directory (default: ~/.copilot)
-  MEMORY_DB_PATH      SQLite database path
-  MEMORY_EXTRA_DIRS   Comma-separated extra directories to index
-  MEMORY_MCP_MODEL    Embedding model (HF URI or local path)
-  MEMORY_CHUNK_SIZE   Chunk size in tokens (default: 512)`);
+Configuration:
+  Settings are read from ~/.copilot/memory-mcp.json (editable via "memory-mcp config set").
+  Environment variables override config file values:
+    MEMORY_WORKSPACE    Root directory (default: ~/.copilot)
+    MEMORY_DB_PATH      SQLite database path
+    MEMORY_EXTRA_DIRS   Comma-separated extra directories to index
+    MEMORY_MCP_MODEL    Embedding model (HF URI or local path)
+    MEMORY_CHUNK_SIZE   Chunk size in tokens (default: 512)`);
 }
 
 function parseArgs(args: string[]): { command: string; query?: string; opts: Record<string, string> } {
@@ -105,14 +78,15 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  const workspaceDir = resolveWorkspaceDir();
-  const dbPath = resolveDbPath();
-  const db = await openDatabase(dbPath, { chunkSize: resolveChunkSize() });
+  const config = loadConfig();
+  const workspaceDir = config.workspace;
+  const dbPath = config.dbPath;
+  const db = await openDatabase(dbPath, { chunkSize: config.chunkSize });
 
   try {
     // Sync before search
-    const extraDirs = resolveExtraDirs();
-    await syncMemoryFiles(db, workspaceDir, { chunkSize: resolveChunkSize(), extraDirs });
+    const extraDirs = resolvedExtraDirs(config);
+    await syncMemoryFiles(db, workspaceDir, { chunkSize: config.chunkSize, extraDirs });
     // Best-effort embedding sync
     try { await syncEmbeddings(db); } catch {}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ Commands:
   status            Show index status
 
 Configuration:
-  Settings are read from ~/.copilot/memory-mcp.json (editable via "memory-mcp config set").
+  Settings are read from ~/memory-mcp.json (editable via "memory-mcp config set").
   Environment variables override config file values:
     MEMORY_WORKSPACE    Root directory (default: ~/.copilot)
     MEMORY_DB_PATH      SQLite database path

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@
  * Centralized configuration for memory-mcp.
  *
  * Priority: config file (~/memory-mcp.json) > built-in defaults.
- * No environment variables — all settings go through the config file.
+ * Copilot CLI and Claude Code share the same config and database.
  */
 
 import fs from "node:fs";
@@ -12,6 +12,12 @@ import path from "node:path";
 // Types
 // ---------------------------------------------------------------------------
 
+export type SessionDirConfig = {
+  dir: string;
+  /** 'copilot' scans {dir}/{uuid}/events.jsonl, 'claude' scans {dir}/{project}/*.jsonl */
+  kind: "copilot" | "claude";
+};
+
 export interface MemoryConfig {
   workspace: string;
   dbPath: string;
@@ -19,6 +25,7 @@ export interface MemoryConfig {
   tokenMax: number;
   sessionDays: number;
   sessionMax: number;
+  sessionDirs: SessionDirConfig[];
   extraDirs: string[];
   model: string;
 }
@@ -32,15 +39,23 @@ export type MemoryConfigFile = Partial<MemoryConfig>;
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? "~";
 
+export const DEFAULT_WORKDIR = path.join(HOME, ".memory-mcp-workdir");
+
 export const DEFAULT_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
 
+export const DEFAULT_SESSION_DIRS: readonly SessionDirConfig[] = [
+  { dir: path.join(HOME, ".copilot", "session-state"), kind: "copilot" },
+  { dir: path.join(HOME, ".claude", "projects"), kind: "claude" },
+];
+
 export const DEFAULTS: Readonly<MemoryConfig> = {
-  workspace: path.join(HOME, ".copilot"),
+  workspace: DEFAULT_WORKDIR,
   dbPath: "", // derived from workspace if empty
   chunkSize: 512,
   tokenMax: 4096,
   sessionDays: 30,
   sessionMax: -1,
+  sessionDirs: DEFAULT_SESSION_DIRS as SessionDirConfig[],
   extraDirs: [],
   model: DEFAULT_MODEL,
 };
@@ -51,9 +66,9 @@ export const CONFIG_FILENAME = "memory-mcp.json";
 // Config file I/O
 // ---------------------------------------------------------------------------
 
-/** Return the config file path (always ~/memory-mcp.json, cross-platform). */
+/** Return the config file path (inside the workdir: ~/.memory-mcp-workdir/memory-mcp.json). */
 export function configFilePath(): string {
-  return path.join(HOME, CONFIG_FILENAME);
+  return path.join(DEFAULT_WORKDIR, CONFIG_FILENAME);
 }
 
 /** Read the config file. Returns {} if missing or invalid. */
@@ -100,27 +115,31 @@ let cachedConfig: MemoryConfig | null = null;
 
 /**
  * Load and merge configuration.
- * Priority: config file > defaults.
- * The result is cached for the process lifetime.
+ * Priority: overrides > config file > defaults.
+ * The result is cached for the process lifetime (only when no overrides are given).
  */
-export function loadConfig(): MemoryConfig {
-  if (cachedConfig) return cachedConfig;
+export function loadConfig(overrides?: MemoryConfigFile, configPath?: string): MemoryConfig {
+  if (!overrides && !configPath && cachedConfig) return cachedConfig;
 
-  const file = readConfigFile();
-  const workspace = file.workspace ?? DEFAULTS.workspace;
+  const file = readConfigFile(configPath);
+  const workspace = overrides?.workspace ?? file.workspace ?? DEFAULTS.workspace;
 
   const config: MemoryConfig = {
     workspace,
-    dbPath: file.dbPath ?? path.join(workspace, "memory.db"),
-    chunkSize: file.chunkSize ?? DEFAULTS.chunkSize,
-    tokenMax: file.tokenMax ?? DEFAULTS.tokenMax,
-    sessionDays: file.sessionDays ?? DEFAULTS.sessionDays,
-    sessionMax: file.sessionMax ?? DEFAULTS.sessionMax,
-    extraDirs: file.extraDirs ?? DEFAULTS.extraDirs,
-    model: file.model ?? DEFAULTS.model,
+    dbPath: overrides?.dbPath ?? file.dbPath ?? path.join(workspace, "memory.db"),
+    chunkSize: overrides?.chunkSize ?? file.chunkSize ?? DEFAULTS.chunkSize,
+    tokenMax: overrides?.tokenMax ?? file.tokenMax ?? DEFAULTS.tokenMax,
+    sessionDays: overrides?.sessionDays ?? file.sessionDays ?? DEFAULTS.sessionDays,
+    sessionMax: overrides?.sessionMax ?? file.sessionMax ?? DEFAULTS.sessionMax,
+    sessionDirs: overrides?.sessionDirs ?? file.sessionDirs ?? DEFAULTS.sessionDirs,
+    extraDirs: overrides?.extraDirs ?? file.extraDirs ?? DEFAULTS.extraDirs,
+    model: overrides?.model ?? file.model ?? DEFAULTS.model,
   };
 
-  cachedConfig = config;
+  // Only cache when using default config (no overrides)
+  if (!overrides && !configPath) {
+    cachedConfig = config;
+  }
   return config;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,9 +50,9 @@ export const CONFIG_FILENAME = "memory-mcp.json";
 // Config file I/O
 // ---------------------------------------------------------------------------
 
-/** Return the config file path for a given workspace (or the default workspace). */
-export function configFilePath(workspaceDir?: string): string {
-  return path.join(workspaceDir ?? DEFAULTS.workspace, CONFIG_FILENAME);
+/** Return the config file path (always ~/memory-mcp.json, cross-platform). */
+export function configFilePath(): string {
+  return path.join(HOME, CONFIG_FILENAME);
 }
 
 /** Read the config file. Returns {} if missing or invalid. */
@@ -137,15 +137,12 @@ let cachedConfig: MemoryConfig | null = null;
 export function loadConfig(): MemoryConfig {
   if (cachedConfig) return cachedConfig;
 
-  // 1. Read file config (need workspace first to find the file)
-  const envWorkspace = envString("MEMORY_WORKSPACE");
-  const fileForLookup = envWorkspace
-    ? configFilePath(envWorkspace)
-    : configFilePath();
-  const file = readConfigFile(fileForLookup);
+  // 1. Read file config (~/memory-mcp.json)
+  const file = readConfigFile();
 
   // 2. Merge: env > file > defaults
-  const workspace = envWorkspace ?? file.workspace ?? DEFAULTS.workspace;
+  const workspace =
+    envString("MEMORY_WORKSPACE") ?? file.workspace ?? DEFAULTS.workspace;
 
   const config: MemoryConfig = {
     workspace,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,197 @@
+/**
+ * Centralized configuration for memory-mcp.
+ *
+ * Priority: environment variable > config file (~/.copilot/memory-mcp.json) > defaults.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MemoryConfig {
+  workspace: string;
+  dbPath: string;
+  chunkSize: number;
+  tokenMax: number;
+  sessionDays: number;
+  sessionMax: number;
+  extraDirs: string[];
+  model: string;
+}
+
+/** Partial config as stored in the JSON file (all fields optional). */
+export type MemoryConfigFile = Partial<MemoryConfig>;
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const HOME = process.env.HOME ?? process.env.USERPROFILE ?? "~";
+
+export const DEFAULT_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
+
+export const DEFAULTS: Readonly<MemoryConfig> = {
+  workspace: path.join(HOME, ".copilot"),
+  dbPath: "", // derived from workspace if empty
+  chunkSize: 512,
+  tokenMax: 4096,
+  sessionDays: 30,
+  sessionMax: -1,
+  extraDirs: [],
+  model: DEFAULT_MODEL,
+};
+
+export const CONFIG_FILENAME = "memory-mcp.json";
+
+// ---------------------------------------------------------------------------
+// Config file I/O
+// ---------------------------------------------------------------------------
+
+/** Return the config file path for a given workspace (or the default workspace). */
+export function configFilePath(workspaceDir?: string): string {
+  return path.join(workspaceDir ?? DEFAULTS.workspace, CONFIG_FILENAME);
+}
+
+/** Read the config file. Returns {} if missing or invalid. */
+export function readConfigFile(filePath?: string): MemoryConfigFile {
+  const p = filePath ?? configFilePath();
+  try {
+    const raw = fs.readFileSync(p, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as MemoryConfigFile;
+    }
+  } catch {
+    // missing or invalid — fine
+  }
+  return {};
+}
+
+/** Save partial config to the file (only non-default values). */
+export function saveConfigFile(partial: MemoryConfigFile, filePath?: string): void {
+  const p = filePath ?? configFilePath();
+  const dir = path.dirname(p);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(p, JSON.stringify(partial, null, 2) + "\n", "utf-8");
+}
+
+/** Delete the config file (reset to defaults). */
+export function deleteConfigFile(filePath?: string): boolean {
+  const p = filePath ?? configFilePath();
+  try {
+    fs.unlinkSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Env var parsing helpers
+// ---------------------------------------------------------------------------
+
+function envString(key: string): string | undefined {
+  const val = process.env[key];
+  return val || undefined; // treat empty string as undefined
+}
+
+function envInt(key: string, min: number, max: number): number | undefined {
+  const raw = envString(key);
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (Number.isFinite(n) && n >= min && n <= max) return n;
+  return undefined;
+}
+
+function envIntLoose(key: string, min: number): number | undefined {
+  const raw = envString(key);
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (Number.isFinite(n) && n >= min) return n;
+  return undefined;
+}
+
+function envStringArray(key: string): string[] | undefined {
+  const raw = envString(key);
+  if (raw === undefined) return undefined;
+  const items = raw.split(",").map((d) => d.trim()).filter(Boolean).map((d) => path.resolve(d));
+  return items.length > 0 ? items : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Load config (merged: env > file > defaults)
+// ---------------------------------------------------------------------------
+
+let cachedConfig: MemoryConfig | null = null;
+
+/**
+ * Load and merge configuration.
+ * Priority: env var > config file > defaults.
+ * The result is cached for the process lifetime.
+ */
+export function loadConfig(): MemoryConfig {
+  if (cachedConfig) return cachedConfig;
+
+  // 1. Read file config (need workspace first to find the file)
+  const envWorkspace = envString("MEMORY_WORKSPACE");
+  const fileForLookup = envWorkspace
+    ? configFilePath(envWorkspace)
+    : configFilePath();
+  const file = readConfigFile(fileForLookup);
+
+  // 2. Merge: env > file > defaults
+  const workspace = envWorkspace ?? file.workspace ?? DEFAULTS.workspace;
+
+  const config: MemoryConfig = {
+    workspace,
+    dbPath:
+      envString("MEMORY_DB_PATH") ??
+      file.dbPath ??
+      path.join(workspace, "memory.db"),
+    chunkSize:
+      envInt("MEMORY_CHUNK_SIZE", 64, 4096) ??
+      file.chunkSize ??
+      DEFAULTS.chunkSize,
+    tokenMax:
+      envInt("MEMORY_TOKEN_MAX", 100, 16384) ??
+      file.tokenMax ??
+      DEFAULTS.tokenMax,
+    sessionDays:
+      envIntLoose("MEMORY_SESSION_DAYS", 0) ??
+      file.sessionDays ??
+      DEFAULTS.sessionDays,
+    sessionMax:
+      envIntLoose("MEMORY_SESSION_MAX", -1) ??
+      file.sessionMax ??
+      DEFAULTS.sessionMax,
+    extraDirs:
+      envStringArray("MEMORY_EXTRA_DIRS") ??
+      file.extraDirs ??
+      DEFAULTS.extraDirs,
+    model:
+      envString("MEMORY_MCP_MODEL") ??
+      file.model ??
+      DEFAULTS.model,
+  };
+
+  cachedConfig = config;
+  return config;
+}
+
+/** Reset the cached config (for testing or after config file changes). */
+export function resetConfigCache(): void {
+  cachedConfig = null;
+}
+
+/**
+ * Resolve extraDirs to undefined if empty (for backward compat with callers
+ * that check `if (extraDirs)` / pass to functions expecting `string[] | undefined`).
+ */
+export function resolvedExtraDirs(config: MemoryConfig): string[] | undefined {
+  return config.extraDirs.length > 0 ? config.extraDirs : undefined;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,14 +96,15 @@ export function saveConfigFile(partial: MemoryConfigFile, filePath?: string): vo
   fs.writeFileSync(p, JSON.stringify(partial, null, 2) + "\n", "utf-8");
 }
 
-/** Delete the config file (reset to defaults). */
+/** Delete the config file (reset to defaults). Returns true if deleted. */
 export function deleteConfigFile(filePath?: string): boolean {
   const p = filePath ?? configFilePath();
   try {
     fs.unlinkSync(p);
     return true;
-  } catch {
-    return false;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
   }
 }
 
@@ -111,20 +112,15 @@ export function deleteConfigFile(filePath?: string): boolean {
 // Load config (file > defaults)
 // ---------------------------------------------------------------------------
 
-let cachedConfig: MemoryConfig | null = null;
-
 /**
  * Load and merge configuration.
  * Priority: overrides > config file > defaults.
- * The result is cached for the process lifetime (only when no overrides are given).
  */
 export function loadConfig(overrides?: MemoryConfigFile, configPath?: string): MemoryConfig {
-  if (!overrides && !configPath && cachedConfig) return cachedConfig;
-
   const file = readConfigFile(configPath);
   const workspace = overrides?.workspace ?? file.workspace ?? DEFAULTS.workspace;
 
-  const config: MemoryConfig = {
+  return {
     workspace,
     dbPath: overrides?.dbPath ?? file.dbPath ?? path.join(workspace, "memory.db"),
     chunkSize: overrides?.chunkSize ?? file.chunkSize ?? DEFAULTS.chunkSize,
@@ -135,17 +131,6 @@ export function loadConfig(overrides?: MemoryConfigFile, configPath?: string): M
     extraDirs: overrides?.extraDirs ?? file.extraDirs ?? DEFAULTS.extraDirs,
     model: overrides?.model ?? file.model ?? DEFAULTS.model,
   };
-
-  // Only cache when using default config (no overrides)
-  if (!overrides && !configPath) {
-    cachedConfig = config;
-  }
-  return config;
-}
-
-/** Reset the cached config (for testing or after config file changes). */
-export function resetConfigCache(): void {
-  cachedConfig = null;
 }
 
 /**
@@ -154,4 +139,84 @@ export function resetConfigCache(): void {
  */
 export function resolvedExtraDirs(config: MemoryConfig): string[] | undefined {
   return config.extraDirs.length > 0 ? config.extraDirs : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Migration from legacy directories (~/.copilot, ~/.claude)
+// ---------------------------------------------------------------------------
+
+const MEMORY_ROOT_FILES = ["MEMORY.md", "memory.md", "MEMORY.txt", "memory.txt"];
+
+function copyIfMissing(src: string, dest: string): boolean {
+  if (fs.existsSync(dest)) return false;
+  const dir = path.dirname(dest);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.copyFileSync(src, dest);
+  return true;
+}
+
+function copyDirMerge(srcDir: string, destDir: string): number {
+  if (!fs.existsSync(srcDir)) return 0;
+  let count = 0;
+  const entries = fs.readdirSync(srcDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(srcDir, entry.name);
+    const destPath = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      count += copyDirMerge(srcPath, destPath);
+    } else if (entry.isFile()) {
+      if (copyIfMissing(srcPath, destPath)) count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Migrate memory files from legacy directories (~/.copilot, ~/.claude) to the new workdir.
+ * Only runs if the new workdir has no MEMORY.md and no memory/ directory.
+ * Safe to call from both setup.ts and server.ts.
+ */
+export function migrateFromLegacyDirs(workspaceDir: string): void {
+  const hasMemoryFile = MEMORY_ROOT_FILES.some((f) => fs.existsSync(path.join(workspaceDir, f)));
+  const hasMemoryDir = fs.existsSync(path.join(workspaceDir, "memory"));
+  if (hasMemoryFile || hasMemoryDir) return;
+
+  const legacyDirs = [
+    path.join(HOME, ".copilot"),
+    path.join(HOME, ".claude"),
+  ];
+
+  let migrated = false;
+
+  for (const legacyDir of legacyDirs) {
+    if (!fs.existsSync(legacyDir)) continue;
+    const label = path.basename(legacyDir);
+
+    for (const file of MEMORY_ROOT_FILES) {
+      const src = path.join(legacyDir, file);
+      if (fs.existsSync(src) && copyIfMissing(src, path.join(workspaceDir, file))) {
+        if (!migrated) {
+          console.error(`[memory-mcp] Migrating memory files to ${workspaceDir}:`);
+          migrated = true;
+        }
+        console.error(`[memory-mcp]   ✓ Copied ${file} from ~/${label}/`);
+      }
+    }
+
+    const srcMemDir = path.join(legacyDir, "memory");
+    if (fs.existsSync(srcMemDir)) {
+      const count = copyDirMerge(srcMemDir, path.join(workspaceDir, "memory"));
+      if (count > 0) {
+        if (!migrated) {
+          console.error(`[memory-mcp] Migrating memory files to ${workspaceDir}:`);
+          migrated = true;
+        }
+        console.error(`[memory-mcp]   ✓ Copied memory/ (${count} files) from ~/${label}/`);
+      }
+    }
+  }
+
+  if (migrated) {
+    console.error("[memory-mcp]   Note: Original files retained. Remove manually when ready.");
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,8 @@
 /**
  * Centralized configuration for memory-mcp.
  *
- * Priority: environment variable > config file (~/.copilot/memory-mcp.json) > defaults.
+ * Priority: config file (~/memory-mcp.json) > built-in defaults.
+ * No environment variables — all settings go through the config file.
  */
 
 import fs from "node:fs";
@@ -92,88 +93,31 @@ export function deleteConfigFile(filePath?: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Env var parsing helpers
-// ---------------------------------------------------------------------------
-
-function envString(key: string): string | undefined {
-  const val = process.env[key];
-  return val || undefined; // treat empty string as undefined
-}
-
-function envInt(key: string, min: number, max: number): number | undefined {
-  const raw = envString(key);
-  if (raw === undefined) return undefined;
-  const n = Number(raw);
-  if (Number.isFinite(n) && n >= min && n <= max) return n;
-  return undefined;
-}
-
-function envIntLoose(key: string, min: number): number | undefined {
-  const raw = envString(key);
-  if (raw === undefined) return undefined;
-  const n = Number(raw);
-  if (Number.isFinite(n) && n >= min) return n;
-  return undefined;
-}
-
-function envStringArray(key: string): string[] | undefined {
-  const raw = envString(key);
-  if (raw === undefined) return undefined;
-  const items = raw.split(",").map((d) => d.trim()).filter(Boolean).map((d) => path.resolve(d));
-  return items.length > 0 ? items : undefined;
-}
-
-// ---------------------------------------------------------------------------
-// Load config (merged: env > file > defaults)
+// Load config (file > defaults)
 // ---------------------------------------------------------------------------
 
 let cachedConfig: MemoryConfig | null = null;
 
 /**
  * Load and merge configuration.
- * Priority: env var > config file > defaults.
+ * Priority: config file > defaults.
  * The result is cached for the process lifetime.
  */
 export function loadConfig(): MemoryConfig {
   if (cachedConfig) return cachedConfig;
 
-  // 1. Read file config (~/memory-mcp.json)
   const file = readConfigFile();
-
-  // 2. Merge: env > file > defaults
-  const workspace =
-    envString("MEMORY_WORKSPACE") ?? file.workspace ?? DEFAULTS.workspace;
+  const workspace = file.workspace ?? DEFAULTS.workspace;
 
   const config: MemoryConfig = {
     workspace,
-    dbPath:
-      envString("MEMORY_DB_PATH") ??
-      file.dbPath ??
-      path.join(workspace, "memory.db"),
-    chunkSize:
-      envInt("MEMORY_CHUNK_SIZE", 64, 4096) ??
-      file.chunkSize ??
-      DEFAULTS.chunkSize,
-    tokenMax:
-      envInt("MEMORY_TOKEN_MAX", 100, 16384) ??
-      file.tokenMax ??
-      DEFAULTS.tokenMax,
-    sessionDays:
-      envIntLoose("MEMORY_SESSION_DAYS", 0) ??
-      file.sessionDays ??
-      DEFAULTS.sessionDays,
-    sessionMax:
-      envIntLoose("MEMORY_SESSION_MAX", -1) ??
-      file.sessionMax ??
-      DEFAULTS.sessionMax,
-    extraDirs:
-      envStringArray("MEMORY_EXTRA_DIRS") ??
-      file.extraDirs ??
-      DEFAULTS.extraDirs,
-    model:
-      envString("MEMORY_MCP_MODEL") ??
-      file.model ??
-      DEFAULTS.model,
+    dbPath: file.dbPath ?? path.join(workspace, "memory.db"),
+    chunkSize: file.chunkSize ?? DEFAULTS.chunkSize,
+    tokenMax: file.tokenMax ?? DEFAULTS.tokenMax,
+    sessionDays: file.sessionDays ?? DEFAULTS.sessionDays,
+    sessionMax: file.sessionMax ?? DEFAULTS.sessionMax,
+    extraDirs: file.extraDirs ?? DEFAULTS.extraDirs,
+    model: file.model ?? DEFAULTS.model,
   };
 
   cachedConfig = config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,9 +112,16 @@ export function deleteConfigFile(filePath?: string): boolean {
 // Load config (file > defaults)
 // ---------------------------------------------------------------------------
 
+/** Clamp a number within [min, max], falling back to fallback if invalid. */
+function clamp(val: number | undefined, min: number, max: number, fallback: number): number {
+  if (val === undefined || !Number.isFinite(val)) return fallback;
+  return Math.max(min, Math.min(max, val));
+}
+
 /**
  * Load and merge configuration.
  * Priority: overrides > config file > defaults.
+ * Numeric fields are clamped to valid ranges (guards against hand-edited JSON).
  */
 export function loadConfig(overrides?: MemoryConfigFile, configPath?: string): MemoryConfig {
   const file = readConfigFile(configPath);
@@ -123,10 +130,10 @@ export function loadConfig(overrides?: MemoryConfigFile, configPath?: string): M
   return {
     workspace,
     dbPath: overrides?.dbPath ?? file.dbPath ?? path.join(workspace, "memory.db"),
-    chunkSize: overrides?.chunkSize ?? file.chunkSize ?? DEFAULTS.chunkSize,
-    tokenMax: overrides?.tokenMax ?? file.tokenMax ?? DEFAULTS.tokenMax,
-    sessionDays: overrides?.sessionDays ?? file.sessionDays ?? DEFAULTS.sessionDays,
-    sessionMax: overrides?.sessionMax ?? file.sessionMax ?? DEFAULTS.sessionMax,
+    chunkSize: clamp(overrides?.chunkSize ?? file.chunkSize, 64, 4096, DEFAULTS.chunkSize),
+    tokenMax: clamp(overrides?.tokenMax ?? file.tokenMax, 100, 16384, DEFAULTS.tokenMax),
+    sessionDays: clamp(overrides?.sessionDays ?? file.sessionDays, 0, Infinity, DEFAULTS.sessionDays),
+    sessionMax: clamp(overrides?.sessionMax ?? file.sessionMax, -1, Infinity, DEFAULTS.sessionMax),
     sessionDirs: overrides?.sessionDirs ?? file.sessionDirs ?? DEFAULTS.sessionDirs,
     extraDirs: overrides?.extraDirs ?? file.extraDirs ?? DEFAULTS.extraDirs,
     model: overrides?.model ?? file.model ?? DEFAULTS.model,

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -1,6 +1,6 @@
 /**
  * Local embedding provider using node-llama-cpp.
- * Model is configurable via config file or MEMORY_MCP_MODEL env var.
+ * Model is configurable via config file (~/.memory-mcp-workdir/memory-mcp.json).
  * Defaults to embeddinggemma-300M. Lazy-loaded on first embedding request.
  * Gracefully unavailable if node-llama-cpp is not installed.
  */

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -12,8 +12,11 @@ function isHfUri(s: string): boolean {
   return s.startsWith("hf:");
 }
 
+/** Cached model spec — read from config once on first use. */
+let cachedModelSpec: string | null = null;
 function resolveModelSpec(): string {
-  return loadConfig().model;
+  if (!cachedModelSpec) cachedModelSpec = loadConfig().model;
+  return cachedModelSpec;
 }
 
 // Lazy-init state

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -1,16 +1,19 @@
 /**
  * Local embedding provider using node-llama-cpp.
- * Model is configurable via MEMORY_MCP_MODEL env var (HF URI or local path).
+ * Model is configurable via config file or MEMORY_MCP_MODEL env var.
  * Defaults to embeddinggemma-300M. Lazy-loaded on first embedding request.
  * Gracefully unavailable if node-llama-cpp is not installed.
  */
 
-const DEFAULT_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
-const ENV_MODEL = process.env.MEMORY_MCP_MODEL || undefined;
+import { loadConfig, DEFAULT_MODEL } from "./config.js";
 
 /** Check if spec is a HF URI (only hf: scheme supported by node-llama-cpp resolveModelFile). */
 function isHfUri(s: string): boolean {
   return s.startsWith("hf:");
+}
+
+function resolveModelSpec(): string {
+  return loadConfig().model;
 }
 
 // Lazy-init state
@@ -41,7 +44,7 @@ async function ensureContext(): Promise<EmbeddingContext> {
     llamaInstance = await nodeLlamaCpp.getLlama({ logLevel: nodeLlamaCpp.LlamaLogLevel.error });
   }
   if (!embeddingModel) {
-    const spec = ENV_MODEL ?? DEFAULT_MODEL;
+    const spec = resolveModelSpec();
     let modelPath: string;
     if (isHfUri(spec)) {
       modelPath = await nodeLlamaCpp.resolveModelFile(spec);
@@ -110,7 +113,7 @@ export async function isEmbeddingAvailable(): Promise<boolean> {
   if (unavailable) return false;
   if (embeddingAvailableCache !== null) return embeddingAvailableCache;
   try {
-    const spec = ENV_MODEL ?? DEFAULT_MODEL;
+    const spec = resolveModelSpec();
     if (isHfUri(spec)) {
       const { resolveModelFile } = await import("node-llama-cpp");
       await resolveModelFile(spec);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { SessionDirConfig } from "./config.js";
 
 /**
  * Build unique aliases for extra directories.
@@ -574,18 +575,14 @@ export function chunkMarkdown(
 
 export type SessionFileEntry = MemoryFileEntry;
 
-type SessionSource = {
-  dir: string;
-  /** 'copilot' scans {dir}/{uuid}/events.jsonl, 'claude' scans {dir}/{project}/*.jsonl */
-  kind: "copilot" | "claude";
-};
+type SessionSource = SessionDirConfig;
 
 /**
  * Resolve session directories for supported host CLIs.
  * Copilot CLI: ~/.copilot/session-state/{uuid}/events.jsonl
  * Claude Code: ~/.claude/projects/{project}/*.jsonl
  */
-function resolveSessionSources(): SessionSource[] {
+function defaultSessionSources(): SessionSource[] {
   const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
   if (!home) return [];
   return [
@@ -598,9 +595,10 @@ function resolveSessionSources(): SessionSource[] {
  * Discover session JSONL files from all supported CLIs,
  * filtered by maxDays and maxCount.
  * maxCount=0 disables session indexing. maxCount=-1 means no count limit.
+ * If sessionDirs is provided, it overrides the default sources entirely.
  */
 export async function listSessionFiles(
-  opts?: { maxDays?: number; maxCount?: number },
+  opts?: { maxDays?: number; maxCount?: number; sessionDirs?: SessionDirConfig[] },
 ): Promise<string[]> {
   const maxCount = opts?.maxCount ?? -1;
   if (maxCount === 0) return [];
@@ -609,7 +607,7 @@ export async function listSessionFiles(
   const cutoff = maxDays > 0 ? Date.now() - maxDays * 24 * 60 * 60 * 1000 : 0;
 
   const candidates: Array<{ path: string; mtimeMs: number }> = [];
-  for (const src of resolveSessionSources()) {
+  for (const src of (opts?.sessionDirs ?? defaultSessionSources())) {
     try {
       const entries = await fs.readdir(src.dir, { withFileTypes: true });
       for (const entry of entries) {

--- a/src/search.ts
+++ b/src/search.ts
@@ -184,10 +184,12 @@ export async function searchMemory(
     results = searchLike(db, cleaned, maxResults, snippetMaxChars, allowedPaths);
   }
 
+  // Boost MEMORY.md before truncation so it isn't cut by maxResults
+  applyMemoryFileBoost(results);
+
   results = results.slice(0, maxResults);
   bumpAccessCount(db, results);
   const boosted = applyAccessBoost(db, results);
-  applyMemoryFileBoost(boosted);
 
   // Tag session chunks with distillation hint (caller decides rendering)
   for (const r of boosted) {

--- a/src/search.ts
+++ b/src/search.ts
@@ -187,6 +187,7 @@ export async function searchMemory(
   results = results.slice(0, maxResults);
   bumpAccessCount(db, results);
   const boosted = applyAccessBoost(db, results);
+  applyMemoryFileBoost(boosted);
 
   // Tag session chunks with distillation hint (caller decides rendering)
   for (const r of boosted) {
@@ -399,3 +400,24 @@ function applyAccessBoost(db: Database.Database, results: SearchResult[]): Searc
 }
 
 // searchFacts removed in schema v8 — facts indexed via normal chunk pipeline
+
+/** Top-level memory files that receive a score boost (long-term memory). */
+const BOOSTED_PATHS = new Set(["MEMORY.md", "memory.md", "MEMORY.txt", "memory.txt"]);
+
+/** Boost factor for top-level memory file results (score × 1.3). */
+const MEMORY_FILE_BOOST = 0.3;
+
+/**
+ * Boost scores for chunks from the top-level MEMORY.md file and re-sort.
+ * MEMORY.md is the user's curated long-term memory — it should rank higher
+ * than session transcripts or sub-directory files at similar relevance.
+ */
+function applyMemoryFileBoost(results: SearchResult[]): void {
+  if (results.length <= 1) return;
+  for (const r of results) {
+    if (BOOSTED_PATHS.has(r.path)) {
+      r.score *= 1 + MEMORY_FILE_BOOST;
+    }
+  }
+  results.sort((a, b) => b.score - a.score);
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -407,6 +407,7 @@ function applyAccessBoost(db: Database.Database, results: SearchResult[]): Searc
 const BOOSTED_PATHS = new Set(["MEMORY.md", "memory.md", "MEMORY.txt", "memory.txt"]);
 
 /** Boost factor for top-level memory file results (score × 1.3). */
+// TODO: consider making this configurable for users who want to boost other files (e.g. extra dirs)
 const MEMORY_FILE_BOOST = 0.3;
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,69 +9,16 @@ import { openDatabase } from "./db.js";
 import { syncMemoryFiles, syncSessionFiles, syncEmbeddings } from "./sync.js";
 import { searchMemory } from "./search.js";
 import { MEMORY_EXTENSIONS, hashText, buildExtraDirAliases } from "./internal.js";
+import { loadConfig, resolvedExtraDirs } from "./config.js";
 
-const DEFAULT_WORKSPACE = path.join(
-  process.env.HOME ?? process.env.USERPROFILE ?? "~",
-  ".copilot",
-);
-
-function resolveWorkspaceDir(): string {
-  return process.env.MEMORY_WORKSPACE ?? DEFAULT_WORKSPACE;
-}
-
-function resolveDbPath(): string {
-  return process.env.MEMORY_DB_PATH ?? path.join(resolveWorkspaceDir(), "memory.db");
-}
-
-function resolveChunkSize(): number {
-  const val = process.env.MEMORY_CHUNK_SIZE;
-  if (val) {
-    const n = Number(val);
-    if (n >= 64 && n <= 4096) return n;
-  }
-  return 512;
-}
-
-function resolveTokenMax(): number {
-  const val = process.env.MEMORY_TOKEN_MAX;
-  if (val) {
-    const n = Number(val);
-    if (n >= 100 && n <= 16384) return n;
-  }
-  return 4096;
-}
-
-function resolveSessionDays(): number {
-  const val = process.env.MEMORY_SESSION_DAYS;
-  if (val) {
-    const n = Number(val);
-    if (Number.isFinite(n) && n >= 0) return n;
-  }
-  return 30;
-}
-
-function resolveSessionMax(): number {
-  const val = process.env.MEMORY_SESSION_MAX;
-  if (val) {
-    const n = Number(val);
-    if (Number.isFinite(n) && n >= -1) return n;
-  }
-  return -1; // no count limit
-}
-
-function resolveExtraDirs(): string[] | undefined {
-  const val = process.env.MEMORY_EXTRA_DIRS;
-  if (!val) return undefined;
-  const dirs = val.split(",").map((d) => d.trim()).filter(Boolean).map((d) => path.resolve(d));
-  return dirs.length > 0 ? dirs : undefined;
-}
+const config = loadConfig();
 
 const server = new McpServer({
   name: "memory",
   version: "0.1.0",
 });
 
-const dbPath = resolveDbPath();
+const dbPath = config.dbPath;
 let db: import("better-sqlite3").Database;
 let lastSyncAt = 0;
 let lastSessionSyncAt = 0;
@@ -86,17 +33,17 @@ async function ensureSynced(): Promise<void> {
   const memoryDue = now - lastSyncAt >= SYNC_COOLDOWN_MS;
   const sessionDue = now - lastSessionSyncAt >= SESSION_SYNC_COOLDOWN_MS;
   if (!memoryDue && !sessionDue) return;
-  const workspaceDir = resolveWorkspaceDir();
+  const workspaceDir = config.workspace;
   try {
     if (memoryDue) {
-      await syncMemoryFiles(db, workspaceDir, { chunkSize: resolveChunkSize(), extraDirs: resolveExtraDirs() });
+      await syncMemoryFiles(db, workspaceDir, { chunkSize: config.chunkSize, extraDirs: resolvedExtraDirs(config) });
       lastSyncAt = Date.now();
     }
     if (sessionDue) {
       await syncSessionFiles(db, {
-        chunkSize: resolveChunkSize(),
-        maxDays: resolveSessionDays(),
-        maxCount: resolveSessionMax(),
+        chunkSize: config.chunkSize,
+        maxDays: config.sessionDays,
+        maxCount: config.sessionMax,
       });
       lastSessionSyncAt = Date.now();
     }
@@ -125,7 +72,7 @@ server.tool(
   },
   async ({ query, maxResults, minScore, tokenMax, after, before }) => {
     await ensureSynced();
-    const effectiveTokenMax = tokenMax ?? resolveTokenMax();
+    const effectiveTokenMax = tokenMax ?? config.tokenMax;
     const results = await searchMemory(db, query, { maxResults, minScore, tokenMax: effectiveTokenMax, after, before });
     return {
       content: [
@@ -147,8 +94,8 @@ server.tool(
     lines: z.number().optional().describe("Number of lines to read (omit to read entire file)"),
   },
   async ({ path: relPath, from, lines }) => {
-    const workspaceDir = resolveWorkspaceDir();
-    const extraDirs = resolveExtraDirs();
+    const workspaceDir = config.workspace;
+    const extraDirs = resolvedExtraDirs(config);
 
     // Resolve extra: prefix paths using alias → directory mapping
     let absPath: string;
@@ -251,7 +198,7 @@ server.tool(
   {},
   async () => {
     await ensureSynced();
-    const workspaceDir = resolveWorkspaceDir();
+    const workspaceDir = config.workspace;
     const fileCount = (db.prepare(`SELECT COUNT(*) as c FROM files`).get() as { c: number }).c;
     const memoryFileCount = (db.prepare(`SELECT COUNT(*) as c FROM files WHERE source = 'memory'`).get() as { c: number }).c;
     const sessionFileCount = (db.prepare(`SELECT COUNT(*) as c FROM files WHERE source = 'sessions'`).get() as { c: number }).c;
@@ -304,10 +251,10 @@ server.tool(
       embeddedChunks: vecCount,
       embeddingCache: cacheCount,
       config: {
-        chunkSize: resolveChunkSize(),
-        tokenMax: resolveTokenMax(),
-        sessionDays: resolveSessionDays(),
-        sessionMax: resolveSessionMax(),
+        chunkSize: config.chunkSize,
+        tokenMax: config.tokenMax,
+        sessionDays: config.sessionDays,
+        sessionMax: config.sessionMax,
       },
       lastSyncAt: lastSyncAt ? new Date(lastSyncAt).toISOString() : null,
       warnings: warnings.length > 0 ? warnings : undefined,
@@ -341,7 +288,7 @@ server.tool(
       .describe("The raw context supporting this fact — conversation excerpt, code snippet, or observation. Auto-chunked and linked for traceability."),
   },
   async ({ content, category, source, evidence }) => {
-    const workspaceDir = resolveWorkspaceDir();
+    const workspaceDir = config.workspace;
     const memoryDir = path.join(workspaceDir, "memory");
 
     if (!fs.existsSync(memoryDir)) {
@@ -540,7 +487,7 @@ async function findMemoryEntry(
   query: string,
   category?: string,
 ): Promise<{ filePath: string; lineIndex: number; line: string } | null> {
-  const workspaceDir = resolveWorkspaceDir();
+  const workspaceDir = config.workspace;
   const normalized = normalizeForMatch(query);
   if (!normalized) return null;
 
@@ -584,13 +531,13 @@ const REF_RE = /\[ref:(memory\/evidence\/[^\]]+)\]/;
 function cleanupEvidence(line: string): void {
   const m = line.match(REF_RE);
   if (!m) return;
-  const absPath = path.join(resolveWorkspaceDir(), m[1]!);
+  const absPath = path.join(config.workspace, m[1]!);
   try { fs.unlinkSync(absPath); } catch {}
 }
 
 /** Write an evidence file and return its path + ref tag. */
 function writeEvidence(fact: string, evidence: string): { path: string; refTag: string } {
-  const memoryDir = path.join(resolveWorkspaceDir(), "memory");
+  const memoryDir = path.join(config.workspace, "memory");
   const evidenceDir = path.join(memoryDir, "evidence");
   if (!fs.existsSync(evidenceDir)) {
     fs.mkdirSync(evidenceDir, { recursive: true });
@@ -631,7 +578,7 @@ server.tool(
     // Clean up orphan evidence file
     cleanupEvidence(match.line);
 
-    const relPath = path.relative(resolveWorkspaceDir(), match.filePath).replace(/\\/g, "/");
+    const relPath = path.relative(config.workspace, match.filePath).replace(/\\/g, "/");
     return {
       content: [{
         type: "text" as const,
@@ -692,7 +639,7 @@ server.tool(
     fs.writeFileSync(match.filePath, lines.join("\n"), "utf-8");
     lastSyncAt = 0;
 
-    const relPath = path.relative(resolveWorkspaceDir(), match.filePath).replace(/\\/g, "/");
+    const relPath = path.relative(config.workspace, match.filePath).replace(/\\/g, "/");
     const result: Record<string, unknown> = { updated: true, path: relPath, old: match.line, new: newEntry };
     if (evidencePath) result.evidencePath = evidencePath;
     return {
@@ -707,7 +654,7 @@ server.tool(
 // --- Start ---
 
 async function main() {
-  db = await openDatabase(dbPath, { chunkSize: resolveChunkSize() });
+  db = await openDatabase(dbPath, { chunkSize: config.chunkSize });
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // Initial sync on startup

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,9 +9,16 @@ import { openDatabase } from "./db.js";
 import { syncMemoryFiles, syncSessionFiles, syncEmbeddings } from "./sync.js";
 import { searchMemory } from "./search.js";
 import { MEMORY_EXTENSIONS, hashText, buildExtraDirAliases } from "./internal.js";
-import { loadConfig, resolvedExtraDirs } from "./config.js";
+import { loadConfig, resolvedExtraDirs, migrateFromLegacyDirs } from "./config.js";
 
 const config = loadConfig();
+
+// Auto-migrate from legacy dirs on first server start (non-fatal)
+try {
+  migrateFromLegacyDirs(config.workspace);
+} catch (err) {
+  console.error("[memory-mcp] migration failed (non-fatal):", err);
+}
 
 const server = new McpServer({
   name: "memory",

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ async function ensureSynced(): Promise<void> {
         chunkSize: config.chunkSize,
         maxDays: config.sessionDays,
         maxCount: config.sessionMax,
+        sessionDirs: config.sessionDirs,
       });
       lastSessionSyncAt = Date.now();
     }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -279,7 +279,7 @@ function handleConfig(args: string[]): void {
   if (!sub || sub === "show") {
     // Show merged config
     const merged = loadConfig();
-    const filePath = configFilePath(merged.workspace);
+    const filePath = configFilePath();
     console.log(`Config file: ${filePath}\n`);
     console.log(JSON.stringify(merged, null, 2));
     return;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -88,11 +88,12 @@ function getHomeDir(): string {
 
 function buildProfile(target: "copilot" | "claude"): TargetProfile {
   const home = getHomeDir();
+  const workspaceDir = DEFAULTS.workspace; // shared: ~/.memory-mcp-workdir
   if (target === "claude") {
     const claudeDir = path.join(home, ".claude");
     return {
       name: "Claude Code",
-      workspaceDir: claudeDir,
+      workspaceDir,
       mcpConfigPath: path.join(home, ".claude.json"),
       instructionsPath: path.join(claudeDir, "CLAUDE.md"),
     };
@@ -100,7 +101,7 @@ function buildProfile(target: "copilot" | "claude"): TargetProfile {
   const copilotDir = path.join(home, ".copilot");
   return {
     name: "Copilot CLI",
-    workspaceDir: copilotDir,
+    workspaceDir,
     mcpConfigPath: path.join(copilotDir, "mcp-config.json"),
     instructionsPath: path.join(copilotDir, "copilot-instructions.md"),
   };
@@ -264,12 +265,104 @@ function uninstall(profile: TargetProfile): void {
 }
 
 // ---------------------------------------------------------------------------
+// Migration from legacy directories (~/.copilot, ~/.claude)
+// ---------------------------------------------------------------------------
+
+/** Top-level memory files to look for in legacy dirs. */
+const MEMORY_ROOT_FILES = ["MEMORY.md", "memory.md", "MEMORY.txt", "memory.txt"];
+
+/**
+ * Copy a file if it doesn't already exist at the destination.
+ * Returns true if copied.
+ */
+function copyIfMissing(src: string, dest: string): boolean {
+  if (fs.existsSync(dest)) return false;
+  const dir = path.dirname(dest);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.copyFileSync(src, dest);
+  return true;
+}
+
+/**
+ * Recursively copy directory contents, skipping files that already exist.
+ * Returns number of files copied.
+ */
+function copyDirMerge(srcDir: string, destDir: string): number {
+  if (!fs.existsSync(srcDir)) return 0;
+  let count = 0;
+  const entries = fs.readdirSync(srcDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(srcDir, entry.name);
+    const destPath = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      count += copyDirMerge(srcPath, destPath);
+    } else if (entry.isFile()) {
+      if (copyIfMissing(srcPath, destPath)) count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Migrate memory files from legacy directories to the new workdir.
+ * Only runs if the new workdir has no MEMORY.md and no memory/ directory.
+ */
+function migrateFromLegacyDirs(workspaceDir: string): void {
+  // Skip if workspace already has content
+  const hasMemoryFile = MEMORY_ROOT_FILES.some((f) => fs.existsSync(path.join(workspaceDir, f)));
+  const hasMemoryDir = fs.existsSync(path.join(workspaceDir, "memory"));
+  if (hasMemoryFile || hasMemoryDir) return;
+
+  const home = getHomeDir();
+  const legacyDirs = [
+    path.join(home, ".copilot"),
+    path.join(home, ".claude"),
+  ];
+
+  let migrated = false;
+
+  for (const legacyDir of legacyDirs) {
+    if (!fs.existsSync(legacyDir)) continue;
+    const label = path.basename(legacyDir);
+
+    // Copy root memory files
+    for (const file of MEMORY_ROOT_FILES) {
+      const src = path.join(legacyDir, file);
+      if (fs.existsSync(src) && copyIfMissing(src, path.join(workspaceDir, file))) {
+        if (!migrated) {
+          console.log(`Migrating memory files to ${workspaceDir}:`);
+          migrated = true;
+        }
+        console.log(`  ✓ Copied ${file} from ~/${label}/`);
+      }
+    }
+
+    // Copy memory/ directory
+    const srcMemDir = path.join(legacyDir, "memory");
+    if (fs.existsSync(srcMemDir)) {
+      const count = copyDirMerge(srcMemDir, path.join(workspaceDir, "memory"));
+      if (count > 0) {
+        if (!migrated) {
+          console.log(`Migrating memory files to ${workspaceDir}:`);
+          migrated = true;
+        }
+        console.log(`  ✓ Copied memory/ (${count} files) from ~/${label}/`);
+      }
+    }
+  }
+
+  if (migrated) {
+    console.log("  Note: Original files retained. Remove manually when ready.\n");
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Config command
 // ---------------------------------------------------------------------------
 
 const CONFIG_KEYS: (keyof MemoryConfig)[] = [
   "workspace", "dbPath", "chunkSize", "tokenMax",
-  "sessionDays", "sessionMax", "extraDirs", "model",
+  "sessionDays", "sessionMax", "sessionDirs", "extraDirs", "model",
 ];
 
 function handleConfig(args: string[]): void {
@@ -322,6 +415,22 @@ function handleConfig(args: string[]): void {
     if (key === "extraDirs") {
       existing.extraDirs = value
         .split(",").map((d) => d.trim()).filter(Boolean).map((d) => path.resolve(d));
+    } else if (key === "sessionDirs") {
+      // JSON input: '[{"dir":"/path","kind":"copilot"}]'
+      try {
+        const parsed = JSON.parse(value);
+        if (!Array.isArray(parsed)) throw new Error("must be an array");
+        for (const item of parsed) {
+          if (!item.dir || !item.kind || !["copilot", "claude"].includes(item.kind)) {
+            throw new Error(`each entry needs {dir, kind: "copilot"|"claude"}`);
+          }
+        }
+        existing.sessionDirs = parsed;
+      } catch (err) {
+        console.error(`sessionDirs must be valid JSON array, e.g. '[{"dir":"/path","kind":"copilot"}]'`);
+        console.error(`Error: ${err instanceof Error ? err.message : err}`);
+        process.exit(1);
+      }
     } else if (key === "chunkSize" || key === "tokenMax" || key === "sessionDays" || key === "sessionMax") {
       const n = Number(value);
       if (!Number.isFinite(n)) {
@@ -395,16 +504,8 @@ The MCP server itself is started automatically by the host CLI.`);
   // --- setup ---
   console.log(`Setting up memory-mcp for ${profile.name}...\n`);
 
-  // For non-default workspace (e.g. --claude), persist workspace in config file
-  if (profile.workspaceDir !== DEFAULTS.workspace) {
-    const existing = readConfigFile();
-    if (existing.workspace !== profile.workspaceDir) {
-      existing.workspace = profile.workspaceDir;
-      saveConfigFile(existing);
-      resetConfigCache();
-      console.log(`✓ Workspace set to ${profile.workspaceDir} in ${configFilePath()}`);
-    }
-  }
+  // Migrate from legacy dirs if this is a fresh workspace
+  migrateFromLegacyDirs(profile.workspaceDir);
 
   const mcpResult = setupMcpConfig(profile);
   console.log(mcpResult.changed ? `✓ ${mcpResult.message}` : `  ${mcpResult.message}`);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   loadConfig, readConfigFile, saveConfigFile, deleteConfigFile,
-  configFilePath, DEFAULTS, resetConfigCache,
+  configFilePath, DEFAULTS, migrateFromLegacyDirs,
   type MemoryConfig, type MemoryConfigFile,
 } from "./config.js";
 
@@ -265,98 +265,6 @@ function uninstall(profile: TargetProfile): void {
 }
 
 // ---------------------------------------------------------------------------
-// Migration from legacy directories (~/.copilot, ~/.claude)
-// ---------------------------------------------------------------------------
-
-/** Top-level memory files to look for in legacy dirs. */
-const MEMORY_ROOT_FILES = ["MEMORY.md", "memory.md", "MEMORY.txt", "memory.txt"];
-
-/**
- * Copy a file if it doesn't already exist at the destination.
- * Returns true if copied.
- */
-function copyIfMissing(src: string, dest: string): boolean {
-  if (fs.existsSync(dest)) return false;
-  const dir = path.dirname(dest);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-  fs.copyFileSync(src, dest);
-  return true;
-}
-
-/**
- * Recursively copy directory contents, skipping files that already exist.
- * Returns number of files copied.
- */
-function copyDirMerge(srcDir: string, destDir: string): number {
-  if (!fs.existsSync(srcDir)) return 0;
-  let count = 0;
-  const entries = fs.readdirSync(srcDir, { withFileTypes: true });
-  for (const entry of entries) {
-    const srcPath = path.join(srcDir, entry.name);
-    const destPath = path.join(destDir, entry.name);
-    if (entry.isDirectory()) {
-      count += copyDirMerge(srcPath, destPath);
-    } else if (entry.isFile()) {
-      if (copyIfMissing(srcPath, destPath)) count++;
-    }
-  }
-  return count;
-}
-
-/**
- * Migrate memory files from legacy directories to the new workdir.
- * Only runs if the new workdir has no MEMORY.md and no memory/ directory.
- */
-function migrateFromLegacyDirs(workspaceDir: string): void {
-  // Skip if workspace already has content
-  const hasMemoryFile = MEMORY_ROOT_FILES.some((f) => fs.existsSync(path.join(workspaceDir, f)));
-  const hasMemoryDir = fs.existsSync(path.join(workspaceDir, "memory"));
-  if (hasMemoryFile || hasMemoryDir) return;
-
-  const home = getHomeDir();
-  const legacyDirs = [
-    path.join(home, ".copilot"),
-    path.join(home, ".claude"),
-  ];
-
-  let migrated = false;
-
-  for (const legacyDir of legacyDirs) {
-    if (!fs.existsSync(legacyDir)) continue;
-    const label = path.basename(legacyDir);
-
-    // Copy root memory files
-    for (const file of MEMORY_ROOT_FILES) {
-      const src = path.join(legacyDir, file);
-      if (fs.existsSync(src) && copyIfMissing(src, path.join(workspaceDir, file))) {
-        if (!migrated) {
-          console.log(`Migrating memory files to ${workspaceDir}:`);
-          migrated = true;
-        }
-        console.log(`  ✓ Copied ${file} from ~/${label}/`);
-      }
-    }
-
-    // Copy memory/ directory
-    const srcMemDir = path.join(legacyDir, "memory");
-    if (fs.existsSync(srcMemDir)) {
-      const count = copyDirMerge(srcMemDir, path.join(workspaceDir, "memory"));
-      if (count > 0) {
-        if (!migrated) {
-          console.log(`Migrating memory files to ${workspaceDir}:`);
-          migrated = true;
-        }
-        console.log(`  ✓ Copied memory/ (${count} files) from ~/${label}/`);
-      }
-    }
-  }
-
-  if (migrated) {
-    console.log("  Note: Original files retained. Remove manually when ready.\n");
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Config command
 // ---------------------------------------------------------------------------
 
@@ -437,6 +345,18 @@ function handleConfig(args: string[]): void {
         console.error(`${key} must be a number, got "${value}"`);
         process.exit(1);
       }
+      // Range validation
+      const ranges: Record<string, [number, number]> = {
+        chunkSize: [64, 4096],
+        tokenMax: [100, 16384],
+        sessionDays: [0, Infinity],
+        sessionMax: [-1, Infinity],
+      };
+      const [min, max] = ranges[key]!;
+      if (n < min || n > max) {
+        console.error(`${key} must be between ${min} and ${max === Infinity ? "∞" : max}, got ${n}`);
+        process.exit(1);
+      }
       existing[key] = n;
     } else {
       // string fields: workspace, dbPath, model
@@ -444,7 +364,6 @@ function handleConfig(args: string[]): void {
     }
 
     saveConfigFile(existing, filePath);
-    resetConfigCache();
     console.log(`✓ ${key} = ${JSON.stringify(existing[key])}`);
     console.log(`  Saved to ${filePath}`);
     return;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -95,7 +95,6 @@ function buildProfile(target: "copilot" | "claude"): TargetProfile {
       workspaceDir: claudeDir,
       mcpConfigPath: path.join(home, ".claude.json"),
       instructionsPath: path.join(claudeDir, "CLAUDE.md"),
-      serverEnv: { MEMORY_WORKSPACE: claudeDir },
     };
   }
   const copilotDir = path.join(home, ".copilot");
@@ -395,6 +394,17 @@ The MCP server itself is started automatically by the host CLI.`);
 
   // --- setup ---
   console.log(`Setting up memory-mcp for ${profile.name}...\n`);
+
+  // For non-default workspace (e.g. --claude), persist workspace in config file
+  if (profile.workspaceDir !== DEFAULTS.workspace) {
+    const existing = readConfigFile();
+    if (existing.workspace !== profile.workspaceDir) {
+      existing.workspace = profile.workspaceDir;
+      saveConfigFile(existing);
+      resetConfigCache();
+      console.log(`✓ Workspace set to ${profile.workspaceDir} in ${configFilePath()}`);
+    }
+  }
 
   const mcpResult = setupMcpConfig(profile);
   console.log(mcpResult.changed ? `✓ ${mcpResult.message}` : `  ${mcpResult.message}`);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -3,6 +3,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  loadConfig, readConfigFile, saveConfigFile, deleteConfigFile,
+  configFilePath, DEFAULTS, resetConfigCache,
+  type MemoryConfig, type MemoryConfigFile,
+} from "./config.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -260,6 +265,89 @@ function uninstall(profile: TargetProfile): void {
 }
 
 // ---------------------------------------------------------------------------
+// Config command
+// ---------------------------------------------------------------------------
+
+const CONFIG_KEYS: (keyof MemoryConfig)[] = [
+  "workspace", "dbPath", "chunkSize", "tokenMax",
+  "sessionDays", "sessionMax", "extraDirs", "model",
+];
+
+function handleConfig(args: string[]): void {
+  const sub = args[0];
+
+  if (!sub || sub === "show") {
+    // Show merged config
+    const merged = loadConfig();
+    const filePath = configFilePath(merged.workspace);
+    console.log(`Config file: ${filePath}\n`);
+    console.log(JSON.stringify(merged, null, 2));
+    return;
+  }
+
+  if (sub === "path") {
+    console.log(configFilePath());
+    return;
+  }
+
+  if (sub === "reset") {
+    const filePath = configFilePath();
+    if (deleteConfigFile(filePath)) {
+      console.log(`✓ Config file deleted: ${filePath}`);
+      console.log("  All settings reset to defaults.");
+    } else {
+      console.log("  No config file found — already using defaults.");
+    }
+    return;
+  }
+
+  if (sub === "set") {
+    const key = args[1] as keyof MemoryConfig | undefined;
+    const value = args[2];
+    if (!key || value === undefined) {
+      console.error("Usage: memory-mcp config set <key> <value>");
+      console.error(`Valid keys: ${CONFIG_KEYS.join(", ")}`);
+      process.exit(1);
+    }
+    if (!CONFIG_KEYS.includes(key)) {
+      console.error(`Unknown config key: ${key}`);
+      console.error(`Valid keys: ${CONFIG_KEYS.join(", ")}`);
+      process.exit(1);
+    }
+
+    // Read existing file config (not merged)
+    const filePath = configFilePath();
+    const existing = readConfigFile(filePath);
+
+    // Parse and validate value
+    if (key === "extraDirs") {
+      existing.extraDirs = value
+        .split(",").map((d) => d.trim()).filter(Boolean).map((d) => path.resolve(d));
+    } else if (key === "chunkSize" || key === "tokenMax" || key === "sessionDays" || key === "sessionMax") {
+      const n = Number(value);
+      if (!Number.isFinite(n)) {
+        console.error(`${key} must be a number, got "${value}"`);
+        process.exit(1);
+      }
+      existing[key] = n;
+    } else {
+      // string fields: workspace, dbPath, model
+      (existing as Record<string, unknown>)[key] = value;
+    }
+
+    saveConfigFile(existing, filePath);
+    resetConfigCache();
+    console.log(`✓ ${key} = ${JSON.stringify(existing[key])}`);
+    console.log(`  Saved to ${filePath}`);
+    return;
+  }
+
+  console.error(`Unknown config subcommand: ${sub}`);
+  console.error("Usage: memory-mcp config [show|set|reset|path]");
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -268,19 +356,28 @@ function main() {
   const command = args[0];
   const flags = new Set(args.slice(1));
 
-  const validCommands = ["setup", "uninstall"];
+  const validCommands = ["setup", "uninstall", "config"];
   if (!command || !validCommands.includes(command)) {
     console.log(`memory-mcp — Local memory management for AI coding assistants
 
 Usage:
   memory-mcp setup [--claude]       Configure MCP server for Copilot CLI (or Claude Code)
   memory-mcp uninstall [--claude]   Remove memory MCP configuration
+  memory-mcp config [show]          Show current merged configuration
+  memory-mcp config set <key> <val> Set a config value
+  memory-mcp config reset           Reset config to defaults
+  memory-mcp config path            Show config file path
 
 Options:
   --claude    Target Claude Code CLI instead of GitHub Copilot CLI
 
 The MCP server itself is started automatically by the host CLI.`);
     process.exit(0);
+  }
+
+  if (command === "config") {
+    handleConfig(args.slice(1));
+    return;
   }
 
   const target = flags.has("--claude") ? "claude" : "copilot";

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import type { SessionDirConfig } from "./config.js";
 import {
   hashText,
   listMemoryFiles,
@@ -160,11 +161,12 @@ function indexFile(
  */
 export async function syncSessionFiles(
   db: Database.Database,
-  opts?: { force?: boolean; chunkSize?: number; maxDays?: number; maxCount?: number },
+  opts?: { force?: boolean; chunkSize?: number; maxDays?: number; maxCount?: number; sessionDirs?: SessionDirConfig[] },
 ): Promise<SyncResult> {
   const files = await listSessionFiles({
     maxDays: opts?.maxDays,
     maxCount: opts?.maxCount,
+    sessionDirs: opts?.sessionDirs,
   });
   const ftsOk = isFtsAvailable(db);
   const activePaths = new Set<string>();


### PR DESCRIPTION
## Summary

Replace scattered environment variables with a centralized config file system. Copilot CLI and Claude Code now share a single workspace and database.

## Changes

### Centralized Config (src/config.ts)
- MemoryConfig type with 9 config fields (including new sessionDirs)
- loadConfig(overrides?, configPath?) — reads config file then defaults, with optional CLI overrides
- Config file: ~/.memory-mcp-workdir/memory-mcp.json
- Auto-migration from legacy ~/.copilot/ and ~/.claude/ directories
- No environment variables — config file is the single source of truth

### Shared Workspace
- Workspace moved to ~/.memory-mcp-workdir/ (was ~/.copilot/ or ~/.claude/)
- Copilot CLI and Claude Code share the same memory.db and memory files

### Configurable Session Sources
- New sessionDirs config field — user-configured overrides replace default scan dirs entirely
- Default: ~/.copilot/session-state (copilot) + ~/.claude/projects (claude)

### CLI Parity
- CLI now syncs session transcripts (was missing syncSessionFiles)
- All config keys available as --flag overrides: --workspace, --chunk-size, etc.
- status output aligned with MCP server

### MEMORY.md Long-Term Memory Boost
- Top-level MEMORY.md search results get a x1.3 score boost (applied before truncation)

### memory-mcp config Subcommand
- memory-mcp config / config set / config reset / config path
- config set validates numeric ranges (chunkSize 64-4096, tokenMax 100-16384, etc.)