### PR TITLE
feat: multi-profile support for isolated memory spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ memory-mcp config profile create coding
 memory-mcp config profile create learning
 
 # Configure each profile independently
-memory-mcp config --profile coding set sessionDirs '[{"dir":"~/.copilot/session-state","kind":"copilot"},{"dir":"~/.claude/projects","kind":"claude"}]'
+memory-mcp config --profile coding set sessionDirs '[{"dir":"/home/user/.copilot/session-state","kind":"copilot"},{"dir":"/home/user/.claude/projects","kind":"claude"}]'
 memory-mcp config --profile learning set extraDirs /path/to/obsidian-vault
 memory-mcp config --profile learning set sessionDirs '[]'
 
@@ -187,6 +187,8 @@ memory-mcp-cli search "query" --profile learning
 # Use a specific profile with the MCP server
 # In your MCP host config (e.g. .claude.json):
 #   "args": ["dist/server.js", "--profile", "coding"]
+# Or via environment variable:
+#   "env": { "MEMORY_MCP_PROFILE": "coding" }
 ```
 
 Each profile workspace lives at `~/.memory-mcp-workdir/<profile-name>/` by default.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,33 @@ memory-mcp config path
 
 Config is stored in `~/.memory-mcp-workdir/memory-mcp.json` (cross-platform: `$HOME` on Linux/macOS, `%USERPROFILE%` on Windows). Changes take effect on next server restart.
 
+### Example Config File
+
+```json
+{
+  "defaultProfile": "default",
+  "profiles": {
+    "default": {
+      "chunkSize": 512,
+      "tokenMax": 4096,
+      "sessionDays": 30,
+      "sessionMax": -1,
+      "sessionDirs": [
+        { "dir": "~/.copilot/session-state", "kind": "copilot" },
+        { "dir": "~/.claude/projects", "kind": "claude" }
+      ]
+    },
+    "learning": {
+      "extraDirs": ["/path/to/obsidian-vault"],
+      "sessionDirs": [],
+      "model": "/path/to/local-model.gguf"
+    }
+  }
+}
+```
+
+Fields omitted from a profile inherit built-in defaults. Each profile workspace is at `~/.memory-mcp-workdir/<profile-name>/` unless overridden.
+
 ### Config Keys
 
 | Key | Default | Description |

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Config is stored in `~/.memory-mcp-workdir/memory-mcp.json` (cross-platform: `$H
       "sessionDays": 30,
       "sessionMax": -1,
       "sessionDirs": [
-        { "dir": "~/.copilot/session-state", "kind": "copilot" },
-        { "dir": "~/.claude/projects", "kind": "claude" }
+        { "dir": "/home/user/.copilot/session-state", "kind": "copilot" },
+        { "dir": "/home/user/.claude/projects", "kind": "claude" }
       ]
     },
     "learning": {
@@ -142,6 +142,8 @@ Config is stored in `~/.memory-mcp-workdir/memory-mcp.json` (cross-platform: `$H
   }
 }
 ```
+
+> **Note:** Use absolute paths in the config file. `~` is not expanded by Node.js.
 
 Fields omitted from a profile inherit built-in defaults. Each profile workspace is at `~/.memory-mcp-workdir/<profile-name>/` unless overridden.
 

--- a/README.md
+++ b/README.md
@@ -56,19 +56,18 @@ This compiles with the correct Windows API path and restores full multi-threaded
 
 ## Usage
 
-All memory data lives in a single shared directory, used by both Copilot CLI and Claude Code:
+All memory data lives in a shared directory under your home folder:
 
 ```
 ~/.memory-mcp-workdir/
-├── memory-mcp.json        # Configuration file
-├── memory.db              # SQLite database (index + vectors)
-├── MEMORY.md              # Top-level memory file
-└── memory/
-    ├── decisions.md       # Architecture decisions
-    ├── preferences.md     # User preferences
-    ├── context.md         # Project context
-    └── evidence/          # Auto-generated evidence files
-        └── a1b2c3d4e5f6.md  # Linked to a fact via [ref:...]
+├── memory-mcp.json              # Configuration file (profiles, settings)
+└── default/                     # Default profile workspace
+    ├── memory.db                # SQLite database (index + vectors)
+    ├── MEMORY.md                # Top-level memory file
+    └── memory/
+        ├── decisions.md         # Architecture decisions
+        ├── preferences.md       # User preferences
+        └── evidence/            # Auto-generated evidence files
 ```
 
 The host CLI will automatically search these files before answering questions about prior work, decisions, or preferences.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Config is stored in `~/.memory-mcp-workdir/memory-mcp.json` (cross-platform: `$H
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `workspace` | `~/.memory-mcp-workdir` | Root directory for memory files and database |
+| `workspace` | `~/.memory-mcp-workdir/<profile>` | Root directory for memory files and database |
 | `dbPath` | `<workspace>/memory.db` | Path to SQLite database |
 | `chunkSize` | `512` | Chunk size in tokens for markdown splitting (64–4096). Changing triggers automatic index rebuild |
 | `tokenMax` | `4096` | Default max tokens per search response (100–16384). Controls snippet length and result count |
@@ -132,6 +132,36 @@ Config is stored in `~/.memory-mcp-workdir/memory-mcp.json` (cross-platform: `$H
 | `sessionDirs` | `[copilot, claude]` | Session transcript sources. Default: `~/.copilot/session-state` (copilot) + `~/.claude/projects` (claude). Set to override entirely. JSON format: `[{"dir":"/path","kind":"copilot"}]` |
 | `extraDirs` | `[]` | Extra directories to index (e.g. Obsidian vault). Files are stored with `extra:<dirname>/` prefix |
 | `model` | `hf:ggml-org/embeddinggemma-300M-GGUF/...` | Embedding model. Accepts a HuggingFace URI (`hf:org/repo/file.gguf`) for auto-download, or a local file path (`/path/to/model.gguf`) |
+
+### Profiles
+
+Profiles let you maintain isolated memory spaces for different use cases (e.g. coding vs learning). Each profile has its own workspace, database, and memory files.
+
+```bash
+# Create profiles
+memory-mcp config profile create coding
+memory-mcp config profile create learning
+
+# Configure each profile independently
+memory-mcp config --profile coding set sessionDirs '[{"dir":"~/.copilot/session-state","kind":"copilot"},{"dir":"~/.claude/projects","kind":"claude"}]'
+memory-mcp config --profile learning set extraDirs /path/to/obsidian-vault
+memory-mcp config --profile learning set sessionDirs '[]'
+
+# Set which profile is used by default (e.g. by the MCP server)
+memory-mcp config profile default coding
+
+# List profiles
+memory-mcp config profile list
+
+# Use a specific profile with the CLI
+memory-mcp-cli search "query" --profile learning
+
+# Use a specific profile with the MCP server
+# In your MCP host config (e.g. .claude.json):
+#   "args": ["dist/server.js", "--profile", "coding"]
+```
+
+Each profile workspace lives at `~/.memory-mcp-workdir/<profile-name>/` by default.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -101,16 +101,25 @@ The host CLI will automatically search these files before answering questions ab
 All settings have sensible defaults and work out of the box. To customize, use the config command:
 
 ```bash
-# Show current config
+# Show current config (uses default profile)
 memory-mcp config
 
-# Set a value
+# Show config for a specific profile
+memory-mcp config --profile learning show
+
+# Set a value (on default profile)
 memory-mcp config set chunkSize 1024
 memory-mcp config set extraDirs /data/obsidian-vault,/data/notes
 memory-mcp config set model /path/to/local-model.gguf
 
-# Reset to defaults
+# Set a value on a specific profile
+memory-mcp config --profile learning set chunkSize 256
+
+# Reset to defaults (all profiles and settings)
 memory-mcp config reset
+
+# Reset a single profile to defaults (keeps the profile entry)
+memory-mcp config --profile learning reset
 
 # Show config file path
 memory-mcp config path
@@ -191,7 +200,7 @@ memory-mcp-cli search "query" --profile learning
 #   "env": { "MEMORY_MCP_PROFILE": "coding" }
 ```
 
-Each profile workspace lives at `~/.memory-mcp-workdir/<profile-name>/` by default.
+Each profile workspace lives at `~/.memory-mcp-workdir/<profile-name>/` by default. Deleting a profile removes its config entry but **retains the workspace directory** on disk — remove it manually if no longer needed.
 
 ## CLI
 
@@ -218,9 +227,14 @@ Output is JSON to stdout, suitable for piping into other tools.
 
 ## Upgrading
 
-When upgrading from a version that used `~/.copilot/` or `~/.claude/` as the workspace, `memory-mcp setup` (or the MCP server on first start) will automatically copy your memory files to `~/.memory-mcp-workdir/`. Original files are preserved — remove them manually when ready.
+When upgrading from a version that used `~/.copilot/` or `~/.claude/` as the workspace, `memory-mcp setup` (or the MCP server on first start) will automatically copy your memory files to `~/.memory-mcp-workdir/default/`. Original files are preserved — remove them manually when ready.
 
-**Breaking change:** All `MEMORY_*` environment variables have been removed. Configuration is now managed entirely through the config file (`~/.memory-mcp-workdir/memory-mcp.json`). Use `memory-mcp config set <key> <value>` to migrate your settings.
+**Config migration:** If your config file uses the legacy flat format (no `profiles` section), it is automatically treated as the `default` profile. On the first operation that creates profiles (e.g. `config profile create`), legacy `workspace` and `dbPath` fields are migrated into `profiles.default` so custom paths are preserved.
+
+**Breaking changes:**
+
+- All `MEMORY_*` environment variables have been removed. Configuration is now managed entirely through the config file (`~/.memory-mcp-workdir/memory-mcp.json`). Use `memory-mcp config set <key> <value>` to migrate your settings.
+- The `--config` CLI flag has been removed. Use `--profile` to select a named profile instead.
 
 ## Uninstall
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,6 +94,10 @@ function extractGlobalOverrides(opts: Record<string, string>): {
   const rest: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(opts)) {
+    if (key === "config") {
+      console.error("[memory-mcp] Warning: --config flag is no longer supported. Use --profile instead.");
+      continue;
+    }
     if (!GLOBAL_FLAGS.has(key)) {
       rest[key] = value;
       continue;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,21 +19,17 @@ Commands:
   search <query>    Search memory files
     --max-results N   Max results (default: 10)
     --min-score N     Minimum relevance score 0-1 (default: 0.01)
-    --token-max N     Max tokens in response (default: 4096)
+    --token-max N     Max tokens in response (default: from config)
 
   status            Show index status
 
-Global flags (override config for this run):
+Global flags:
   --profile <name>      Use a named profile (default: from config)
-  --config <path>       Use a custom config file
-  --workspace <path>    Override workspace directory
-  --db-path <path>      Override database path
-  --chunk-size N        Override chunk size
-  --session-days N      Override session days
-  --session-max N       Override session max
-  --session-dirs <json> Override session dirs (JSON array)
-  --extra-dirs <paths>  Override extra dirs (comma-separated)
-  --model <path>        Override embedding model
+
+  Override config for this run (optional):
+    --workspace <path>    --db-path <path>      --chunk-size N
+    --session-days N      --session-max N       --model <path>
+    --session-dirs <json> --extra-dirs <paths>
 
 Configuration:
   All settings are read from ~/.memory-mcp-workdir/memory-mcp.json.
@@ -83,19 +79,17 @@ function parsePositiveFloat(val: string | undefined, name: string): number | und
 
 /** Global config flags (kebab-case). Extracted before command-specific parsing. */
 const GLOBAL_FLAGS = new Set([
-  "config", "profile", "workspace", "db-path", "chunk-size", "token-max",
+  "profile", "workspace", "db-path", "chunk-size", "token-max",
   "session-days", "session-max", "session-dirs", "extra-dirs", "model",
 ]);
 
-/** Extract global config overrides from opts, returning {overrides, configPath, profile, rest}. */
+/** Extract global config overrides from opts, returning {overrides, profile, rest}. */
 function extractGlobalOverrides(opts: Record<string, string>): {
   overrides: MemoryConfigFile;
-  configPath?: string;
   profile?: string;
   rest: Record<string, string>;
 } {
   const overrides: MemoryConfigFile = {};
-  let configPath: string | undefined;
   let profile: string | undefined;
   const rest: Record<string, string> = {};
 
@@ -105,7 +99,6 @@ function extractGlobalOverrides(opts: Record<string, string>): {
       continue;
     }
     switch (key) {
-      case "config": configPath = value; break;
       case "profile": profile = value; break;
       case "workspace": overrides.workspace = path.resolve(value); break;
       case "db-path": overrides.dbPath = path.resolve(value); break;
@@ -125,7 +118,7 @@ function extractGlobalOverrides(opts: Record<string, string>): {
     }
   }
 
-  return { overrides, configPath, profile, rest };
+  return { overrides, profile, rest };
 }
 
 async function main(): Promise<void> {
@@ -136,10 +129,10 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  const { overrides, configPath, profile, rest } = extractGlobalOverrides(opts);
-  const hasOpts = Object.keys(overrides).length > 0 || configPath || profile;
+  const { overrides, profile, rest } = extractGlobalOverrides(opts);
+  const hasOpts = Object.keys(overrides).length > 0 || profile;
   const config = hasOpts
-    ? loadConfig({ profile, overrides, configPath })
+    ? loadConfig({ profile, overrides })
     : loadConfig();
   const workspaceDir = config.workspace;
   const dbPath = config.dbPath;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { openDatabase } from "./db.js";
 import { syncMemoryFiles, syncSessionFiles, syncEmbeddings } from "./sync.js";
 import { searchMemory } from "./search.js";
 import { loadConfig, resolvedExtraDirs, type MemoryConfigFile } from "./config.js";
+import { setModelSpec } from "./embedding.js";
 
 function printUsage(): void {
   console.error(`Usage: memory-mcp-cli <command> [options]
@@ -138,6 +139,7 @@ async function main(): Promise<void> {
   const config = hasOpts
     ? loadConfig({ profile, overrides })
     : loadConfig();
+  setModelSpec(config.model);
   const workspaceDir = config.workspace;
   const dbPath = config.dbPath;
   const db = await openDatabase(dbPath, { chunkSize: config.chunkSize });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ Commands:
   status            Show index status
 
 Global flags (override config for this run):
+  --profile <name>      Use a named profile (default: from config)
   --config <path>       Use a custom config file
   --workspace <path>    Override workspace directory
   --db-path <path>      Override database path
@@ -37,8 +38,9 @@ Global flags (override config for this run):
 Configuration:
   All settings are read from ~/.memory-mcp-workdir/memory-mcp.json.
   Config is managed via the "memory-mcp" command (not memory-mcp-cli):
-    memory-mcp config            Show current settings
-    memory-mcp config set <k> <v> Set a value`);
+    memory-mcp config                       Show current settings
+    memory-mcp config --profile <n> show    Show profile settings
+    memory-mcp config profile list          List all profiles`);
 }
 
 function parseArgs(args: string[]): { command: string; query?: string; opts: Record<string, string> } {
@@ -81,18 +83,20 @@ function parsePositiveFloat(val: string | undefined, name: string): number | und
 
 /** Global config flags (kebab-case). Extracted before command-specific parsing. */
 const GLOBAL_FLAGS = new Set([
-  "config", "workspace", "db-path", "chunk-size", "token-max",
+  "config", "profile", "workspace", "db-path", "chunk-size", "token-max",
   "session-days", "session-max", "session-dirs", "extra-dirs", "model",
 ]);
 
-/** Extract global config overrides from opts, returning {overrides, configPath, rest}. */
+/** Extract global config overrides from opts, returning {overrides, configPath, profile, rest}. */
 function extractGlobalOverrides(opts: Record<string, string>): {
   overrides: MemoryConfigFile;
   configPath?: string;
+  profile?: string;
   rest: Record<string, string>;
 } {
   const overrides: MemoryConfigFile = {};
   let configPath: string | undefined;
+  let profile: string | undefined;
   const rest: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(opts)) {
@@ -102,6 +106,7 @@ function extractGlobalOverrides(opts: Record<string, string>): {
     }
     switch (key) {
       case "config": configPath = value; break;
+      case "profile": profile = value; break;
       case "workspace": overrides.workspace = path.resolve(value); break;
       case "db-path": overrides.dbPath = path.resolve(value); break;
       case "chunk-size": overrides.chunkSize = Number(value); break;
@@ -120,7 +125,7 @@ function extractGlobalOverrides(opts: Record<string, string>): {
     }
   }
 
-  return { overrides, configPath, rest };
+  return { overrides, configPath, profile, rest };
 }
 
 async function main(): Promise<void> {
@@ -131,9 +136,11 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  const { overrides, configPath, rest } = extractGlobalOverrides(opts);
-  const hasOverrides = Object.keys(overrides).length > 0 || configPath;
-  const config = hasOverrides ? loadConfig(overrides, configPath) : loadConfig();
+  const { overrides, configPath, profile, rest } = extractGlobalOverrides(opts);
+  const hasOpts = Object.keys(overrides).length > 0 || configPath || profile;
+  const config = hasOpts
+    ? loadConfig({ profile, overrides, configPath })
+    : loadConfig();
   const workspaceDir = config.workspace;
   const dbPath = config.dbPath;
   const db = await openDatabase(dbPath, { chunkSize: config.chunkSize });

--- a/src/config.ts
+++ b/src/config.ts
@@ -153,14 +153,18 @@ export function loadConfig(
 
   // Merge: profile-specific fields over top-level fields
   const profileData = fileData.profiles?.[profileName] ?? {};
+  const isLegacyFormat = !fileData.profiles;
 
-  // Top-level fields (legacy flat format or shared defaults), excluding workspace
-  // workspace is NOT inherited from top-level to avoid legacy flat config polluting new profiles
-  const { profiles: _, defaultProfile: __, workspace: _topWorkspace, ...topLevel } = fileData;
+  // Top-level fields (legacy flat format or shared defaults)
+  // In legacy format (no profiles section): inherit top-level workspace for backward compat
+  // In profile format: workspace only comes from profile or profileName to avoid cross-pollution
+  const { profiles: _, defaultProfile: __, ...topLevel } = fileData;
   const file: MemoryConfigFile = { ...topLevel, ...profileData };
 
   const overrides = opts?.overrides;
-  const workspace = overrides?.workspace ?? profileData.workspace
+  const workspace = overrides?.workspace
+    ?? profileData.workspace
+    ?? (isLegacyFormat ? topLevel.workspace : undefined)
     ?? path.join(DEFAULT_WORKDIR, profileName);
 
   return {
@@ -303,11 +307,14 @@ export function migrateFromLegacyDirs(workspaceDir: string): void {
   const hasMemoryDir = fs.existsSync(path.join(workspaceDir, "memory"));
   if (hasMemoryFile || hasMemoryDir) return;
 
-  // Legacy sources: ~/.copilot, ~/.claude, and the workdir root (pre-profile layout)
+  // Legacy sources: ~/.copilot, ~/.claude
+  // Also include workdir root (pre-profile layout) but ONLY for the default profile
+  // to prevent old root data from bleeding into every new profile
+  const isDefaultProfile = workspaceDir === path.join(DEFAULT_WORKDIR, DEFAULT_PROFILE);
   const legacyDirs = [
     path.join(HOME, ".copilot"),
     path.join(HOME, ".claude"),
-    DEFAULT_WORKDIR, // pre-profile: files were in workdir root, not /default/
+    ...(isDefaultProfile ? [DEFAULT_WORKDIR] : []),
   ].filter((d) => d !== workspaceDir); // don't migrate from self
 
   let migrated = false;

--- a/src/config.ts
+++ b/src/config.ts
@@ -262,13 +262,15 @@ export function resetProfile(profileName: string, configPath?: string): boolean 
   return true;
 }
 
-/** Set the default profile. */
-export function setDefaultProfile(profileName: string, configPath?: string): void {
+/** Set the default profile. Returns false if the profile doesn't exist. */
+export function setDefaultProfile(profileName: string, configPath?: string): boolean {
   validateProfileName(profileName);
   const filePath = configPath ?? configFilePath();
   const fileData = readConfigFile(filePath);
+  if (!fileData.profiles?.[profileName]) return false;
   fileData.defaultProfile = profileName;
   saveConfigFile(fileData, filePath);
+  return true;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -207,7 +207,13 @@ export function saveProfileConfig(
   validateProfileName(profileName);
   const filePath = configPath ?? configFilePath();
   const fileData = readConfigFile(filePath);
+
+  // Migrate legacy flat format: preserve top-level workspace in default profile
+  if (!fileData.profiles && fileData.workspace) {
+    fileData.profiles = { [DEFAULT_PROFILE]: { workspace: fileData.workspace } };
+  }
   if (!fileData.profiles) fileData.profiles = {};
+
   fileData.profiles[profileName] = { ...(fileData.profiles[profileName] ?? {}), ...partial };
   saveConfigFile(fileData, filePath);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,14 @@ export interface MemoryConfig {
 /** Partial config as stored in the JSON file (all fields optional). */
 export type MemoryConfigFile = Partial<MemoryConfig>;
 
+/** Config file structure with multi-profile support. */
+export type ConfigFileData = MemoryConfigFile & {
+  defaultProfile?: string;
+  profiles?: Record<string, MemoryConfigFile>;
+};
+
+export const DEFAULT_PROFILE = "default";
+
 // ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
@@ -72,13 +80,13 @@ export function configFilePath(): string {
 }
 
 /** Read the config file. Returns {} if missing or invalid. */
-export function readConfigFile(filePath?: string): MemoryConfigFile {
+export function readConfigFile(filePath?: string): ConfigFileData {
   const p = filePath ?? configFilePath();
   try {
     const raw = fs.readFileSync(p, "utf-8");
     const parsed = JSON.parse(raw);
     if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
-      return parsed as MemoryConfigFile;
+      return parsed as ConfigFileData;
     }
   } catch {
     // missing or invalid — fine
@@ -86,14 +94,14 @@ export function readConfigFile(filePath?: string): MemoryConfigFile {
   return {};
 }
 
-/** Save partial config to the file (only non-default values). */
-export function saveConfigFile(partial: MemoryConfigFile, filePath?: string): void {
+/** Save config data to the file. */
+export function saveConfigFile(data: ConfigFileData, filePath?: string): void {
   const p = filePath ?? configFilePath();
   const dir = path.dirname(p);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-  fs.writeFileSync(p, JSON.stringify(partial, null, 2) + "\n", "utf-8");
+  fs.writeFileSync(p, JSON.stringify(data, null, 2) + "\n", "utf-8");
 }
 
 /** Delete the config file (reset to defaults). Returns true if deleted. */
@@ -119,13 +127,31 @@ function clamp(val: number | undefined, min: number, max: number, fallback: numb
 }
 
 /**
- * Load and merge configuration.
- * Priority: overrides > config file > defaults.
+ * Load and merge configuration for a specific profile.
+ * Priority: overrides > profile config > top-level config > defaults.
  * Numeric fields are clamped to valid ranges (guards against hand-edited JSON).
+ *
+ * If the config file uses the legacy flat format (no profiles section),
+ * it's treated as a single "default" profile for backward compatibility.
  */
-export function loadConfig(overrides?: MemoryConfigFile, configPath?: string): MemoryConfig {
-  const file = readConfigFile(configPath);
-  const workspace = overrides?.workspace ?? file.workspace ?? DEFAULTS.workspace;
+export function loadConfig(
+  opts?: { profile?: string; overrides?: MemoryConfigFile; configPath?: string },
+): MemoryConfig {
+  const fileData = readConfigFile(opts?.configPath);
+
+  // Determine which profile to use
+  const profileName = opts?.profile ?? fileData.defaultProfile ?? DEFAULT_PROFILE;
+
+  // Merge: profile-specific fields over top-level fields
+  const profileData = fileData.profiles?.[profileName] ?? {};
+
+  // Top-level fields (legacy flat format or shared defaults)
+  const { profiles: _, defaultProfile: __, ...topLevel } = fileData;
+  const file: MemoryConfigFile = { ...topLevel, ...profileData };
+
+  const overrides = opts?.overrides;
+  const workspace = overrides?.workspace ?? file.workspace
+    ?? path.join(DEFAULT_WORKDIR, profileName);
 
   return {
     workspace,
@@ -138,6 +164,71 @@ export function loadConfig(overrides?: MemoryConfigFile, configPath?: string): M
     extraDirs: overrides?.extraDirs ?? file.extraDirs ?? DEFAULTS.extraDirs,
     model: overrides?.model ?? file.model ?? DEFAULTS.model,
   };
+}
+
+/** List all profile names from the config file. Always includes the default profile. */
+export function listProfiles(configPath?: string): string[] {
+  const fileData = readConfigFile(configPath);
+  const defaultP = fileData.defaultProfile ?? DEFAULT_PROFILE;
+  if (fileData.profiles) {
+    const names = new Set(Object.keys(fileData.profiles));
+    names.add(defaultP);
+    return Array.from(names);
+  }
+  return [defaultP];
+}
+
+/** Get the default profile name. */
+export function getDefaultProfile(configPath?: string): string {
+  const fileData = readConfigFile(configPath);
+  return fileData.defaultProfile ?? DEFAULT_PROFILE;
+}
+
+/** Save config for a specific profile. */
+export function saveProfileConfig(
+  profileName: string,
+  partial: MemoryConfigFile,
+  configPath?: string,
+): void {
+  const filePath = configPath ?? configFilePath();
+  const fileData = readConfigFile(filePath);
+  if (!fileData.profiles) fileData.profiles = {};
+  fileData.profiles[profileName] = { ...(fileData.profiles[profileName] ?? {}), ...partial };
+  saveConfigFile(fileData, filePath);
+}
+
+/** Create a new profile (empty config). Returns false if already exists. */
+export function createProfile(profileName: string, configPath?: string): boolean {
+  const filePath = configPath ?? configFilePath();
+  const fileData = readConfigFile(filePath);
+  if (!fileData.profiles) fileData.profiles = {};
+  if (fileData.profiles[profileName]) return false;
+  fileData.profiles[profileName] = {};
+  if (!fileData.defaultProfile) fileData.defaultProfile = profileName;
+  saveConfigFile(fileData, filePath);
+  return true;
+}
+
+/** Delete a profile. Returns false if not found. */
+export function deleteProfile(profileName: string, configPath?: string): boolean {
+  const filePath = configPath ?? configFilePath();
+  const fileData = readConfigFile(filePath);
+  if (!fileData.profiles?.[profileName]) return false;
+  delete fileData.profiles[profileName];
+  if (fileData.defaultProfile === profileName) {
+    const remaining = Object.keys(fileData.profiles);
+    fileData.defaultProfile = remaining[0] ?? DEFAULT_PROFILE;
+  }
+  saveConfigFile(fileData, filePath);
+  return true;
+}
+
+/** Set the default profile. */
+export function setDefaultProfile(profileName: string, configPath?: string): void {
+  const filePath = configPath ?? configFilePath();
+  const fileData = readConfigFile(filePath);
+  fileData.defaultProfile = profileName;
+  saveConfigFile(fileData, filePath);
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,14 @@ export type ConfigFileData = MemoryConfigFile & {
 
 export const DEFAULT_PROFILE = "default";
 
+/** Validate profile name: only [a-zA-Z0-9_-], no path traversal. */
+const VALID_PROFILE_RE = /^[a-zA-Z0-9_-]+$/;
+export function validateProfileName(name: string): void {
+  if (!VALID_PROFILE_RE.test(name)) {
+    throw new Error(`Invalid profile name "${name}". Only letters, numbers, hyphens and underscores allowed.`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------
@@ -141,16 +149,18 @@ export function loadConfig(
 
   // Determine which profile to use
   const profileName = opts?.profile ?? fileData.defaultProfile ?? DEFAULT_PROFILE;
+  validateProfileName(profileName);
 
   // Merge: profile-specific fields over top-level fields
   const profileData = fileData.profiles?.[profileName] ?? {};
 
-  // Top-level fields (legacy flat format or shared defaults)
-  const { profiles: _, defaultProfile: __, ...topLevel } = fileData;
+  // Top-level fields (legacy flat format or shared defaults), excluding workspace
+  // workspace is NOT inherited from top-level to avoid legacy flat config polluting new profiles
+  const { profiles: _, defaultProfile: __, workspace: _topWorkspace, ...topLevel } = fileData;
   const file: MemoryConfigFile = { ...topLevel, ...profileData };
 
   const overrides = opts?.overrides;
-  const workspace = overrides?.workspace ?? file.workspace
+  const workspace = overrides?.workspace ?? profileData.workspace
     ?? path.join(DEFAULT_WORKDIR, profileName);
 
   return {
@@ -190,6 +200,7 @@ export function saveProfileConfig(
   partial: MemoryConfigFile,
   configPath?: string,
 ): void {
+  validateProfileName(profileName);
   const filePath = configPath ?? configFilePath();
   const fileData = readConfigFile(filePath);
   if (!fileData.profiles) fileData.profiles = {};
@@ -199,18 +210,19 @@ export function saveProfileConfig(
 
 /** Create a new profile (empty config). Returns false if already exists. */
 export function createProfile(profileName: string, configPath?: string): boolean {
+  validateProfileName(profileName);
   const filePath = configPath ?? configFilePath();
   const fileData = readConfigFile(filePath);
   if (!fileData.profiles) fileData.profiles = {};
   if (fileData.profiles[profileName]) return false;
   fileData.profiles[profileName] = {};
-  if (!fileData.defaultProfile) fileData.defaultProfile = profileName;
   saveConfigFile(fileData, filePath);
   return true;
 }
 
 /** Delete a profile. Returns false if not found. */
 export function deleteProfile(profileName: string, configPath?: string): boolean {
+  validateProfileName(profileName);
   const filePath = configPath ?? configFilePath();
   const fileData = readConfigFile(filePath);
   if (!fileData.profiles?.[profileName]) return false;
@@ -223,8 +235,20 @@ export function deleteProfile(profileName: string, configPath?: string): boolean
   return true;
 }
 
+/** Reset a profile config to empty (keeps the profile entry). Returns false if not found. */
+export function resetProfile(profileName: string, configPath?: string): boolean {
+  validateProfileName(profileName);
+  const filePath = configPath ?? configFilePath();
+  const fileData = readConfigFile(filePath);
+  if (!fileData.profiles?.[profileName]) return false;
+  fileData.profiles[profileName] = {};
+  saveConfigFile(fileData, filePath);
+  return true;
+}
+
 /** Set the default profile. */
 export function setDefaultProfile(profileName: string, configPath?: string): void {
+  validateProfileName(profileName);
   const filePath = configPath ?? configFilePath();
   const fileData = readConfigFile(filePath);
   fileData.defaultProfile = profileName;

--- a/src/config.ts
+++ b/src/config.ts
@@ -202,12 +202,17 @@ export function getDefaultProfile(configPath?: string): string {
   return fileData.defaultProfile ?? DEFAULT_PROFILE;
 }
 
-/** Ensure fileData has a profiles section. Migrates legacy workspace if needed. */
+/** Ensure fileData has a profiles section. Migrates legacy flat fields if needed. */
 function ensureProfilesSection(fileData: ConfigFileData): void {
-  if (!fileData.profiles && fileData.workspace) {
-    fileData.profiles = { [DEFAULT_PROFILE]: { workspace: fileData.workspace } };
+  if (!fileData.profiles) {
+    // Migrate all profile-scoped legacy fields into profiles.default
+    const legacy: MemoryConfigFile = {};
+    if (fileData.workspace) legacy.workspace = fileData.workspace;
+    if (fileData.dbPath) legacy.dbPath = fileData.dbPath;
+    fileData.profiles = Object.keys(legacy).length > 0
+      ? { [DEFAULT_PROFILE]: legacy }
+      : {};
   }
-  if (!fileData.profiles) fileData.profiles = {};
 }
 
 /** Save config for a specific profile. */

--- a/src/config.ts
+++ b/src/config.ts
@@ -169,7 +169,11 @@ export function loadConfig(
 
   return {
     workspace,
-    dbPath: overrides?.dbPath ?? file.dbPath ?? path.join(workspace, "memory.db"),
+    // dbPath: like workspace, not inherited from top-level in profile mode to maintain isolation
+    dbPath: overrides?.dbPath
+      ?? profileData.dbPath
+      ?? (isLegacyFormat ? topLevel.dbPath : undefined)
+      ?? path.join(workspace, "memory.db"),
     chunkSize: clamp(overrides?.chunkSize ?? file.chunkSize, 64, 4096, DEFAULTS.chunkSize),
     tokenMax: clamp(overrides?.tokenMax ?? file.tokenMax, 100, 16384, DEFAULTS.tokenMax),
     sessionDays: clamp(overrides?.sessionDays ?? file.sessionDays, 0, Infinity, DEFAULTS.sessionDays),
@@ -198,6 +202,14 @@ export function getDefaultProfile(configPath?: string): string {
   return fileData.defaultProfile ?? DEFAULT_PROFILE;
 }
 
+/** Ensure fileData has a profiles section. Migrates legacy workspace if needed. */
+function ensureProfilesSection(fileData: ConfigFileData): void {
+  if (!fileData.profiles && fileData.workspace) {
+    fileData.profiles = { [DEFAULT_PROFILE]: { workspace: fileData.workspace } };
+  }
+  if (!fileData.profiles) fileData.profiles = {};
+}
+
 /** Save config for a specific profile. */
 export function saveProfileConfig(
   profileName: string,
@@ -207,14 +219,13 @@ export function saveProfileConfig(
   validateProfileName(profileName);
   const filePath = configPath ?? configFilePath();
   const fileData = readConfigFile(filePath);
+  ensureProfilesSection(fileData);
 
-  // Migrate legacy flat format: preserve top-level workspace in default profile
-  if (!fileData.profiles && fileData.workspace) {
-    fileData.profiles = { [DEFAULT_PROFILE]: { workspace: fileData.workspace } };
+  if (!fileData.profiles![profileName]) {
+    console.error(`[memory-mcp] Note: Profile "${profileName}" created implicitly via config set.`);
   }
-  if (!fileData.profiles) fileData.profiles = {};
 
-  fileData.profiles[profileName] = { ...(fileData.profiles[profileName] ?? {}), ...partial };
+  fileData.profiles![profileName] = { ...(fileData.profiles![profileName] ?? {}), ...partial };
   saveConfigFile(fileData, filePath);
 }
 
@@ -223,15 +234,10 @@ export function createProfile(profileName: string, configPath?: string): boolean
   validateProfileName(profileName);
   const filePath = configPath ?? configFilePath();
   const fileData = readConfigFile(filePath);
+  ensureProfilesSection(fileData);
 
-  // Migrate legacy flat format: preserve top-level workspace in default profile
-  if (!fileData.profiles && fileData.workspace) {
-    fileData.profiles = { [DEFAULT_PROFILE]: { workspace: fileData.workspace } };
-  }
-  if (!fileData.profiles) fileData.profiles = {};
-
-  if (fileData.profiles[profileName]) return false;
-  fileData.profiles[profileName] = {};
+  if (fileData.profiles![profileName]) return false;
+  fileData.profiles![profileName] = {};
   saveConfigFile(fileData, filePath);
   return true;
 }
@@ -245,6 +251,9 @@ export function deleteProfile(profileName: string, configPath?: string): boolean
   delete fileData.profiles[profileName];
   if (fileData.defaultProfile === profileName) {
     const remaining = Object.keys(fileData.profiles);
+    if (remaining.length === 0) {
+      console.error(`[memory-mcp] Warning: No profiles remaining. Default reset to "${DEFAULT_PROFILE}".`);
+    }
     fileData.defaultProfile = remaining[0] ?? DEFAULT_PROFILE;
   }
   saveConfigFile(fileData, filePath);

--- a/src/config.ts
+++ b/src/config.ts
@@ -223,7 +223,13 @@ export function createProfile(profileName: string, configPath?: string): boolean
   validateProfileName(profileName);
   const filePath = configPath ?? configFilePath();
   const fileData = readConfigFile(filePath);
+
+  // Migrate legacy flat format: preserve top-level workspace in default profile
+  if (!fileData.profiles && fileData.workspace) {
+    fileData.profiles = { [DEFAULT_PROFILE]: { workspace: fileData.workspace } };
+  }
   if (!fileData.profiles) fileData.profiles = {};
+
   if (fileData.profiles[profileName]) return false;
   fileData.profiles[profileName] = {};
   saveConfigFile(fileData, filePath);

--- a/src/config.ts
+++ b/src/config.ts
@@ -279,10 +279,12 @@ export function migrateFromLegacyDirs(workspaceDir: string): void {
   const hasMemoryDir = fs.existsSync(path.join(workspaceDir, "memory"));
   if (hasMemoryFile || hasMemoryDir) return;
 
+  // Legacy sources: ~/.copilot, ~/.claude, and the workdir root (pre-profile layout)
   const legacyDirs = [
     path.join(HOME, ".copilot"),
     path.join(HOME, ".claude"),
-  ];
+    DEFAULT_WORKDIR, // pre-profile: files were in workdir root, not /default/
+  ].filter((d) => d !== workspaceDir); // don't migrate from self
 
   let migrated = false;
 

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -12,8 +12,14 @@ function isHfUri(s: string): boolean {
   return s.startsWith("hf:");
 }
 
-/** Cached model spec — read from config once on first use. */
+/** Cached model spec — set once by the caller (server/cli) or read from default config. */
 let cachedModelSpec: string | null = null;
+
+/** Set the model spec from the resolved config. Call before first embedding use. */
+export function setModelSpec(model: string): void {
+  cachedModelSpec = model;
+}
+
 function resolveModelSpec(): string {
   if (!cachedModelSpec) cachedModelSpec = loadConfig().model;
   return cachedModelSpec;

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,13 @@ import { searchMemory } from "./search.js";
 import { MEMORY_EXTENSIONS, hashText, buildExtraDirAliases } from "./internal.js";
 import { loadConfig, resolvedExtraDirs, migrateFromLegacyDirs } from "./config.js";
 
-const config = loadConfig();
+// Parse --profile from process.argv (before MCP takes over stdio)
+const serverProfile = (() => {
+  const idx = process.argv.indexOf("--profile");
+  return idx >= 0 && process.argv[idx + 1] ? process.argv[idx + 1] : undefined;
+})();
+
+const config = loadConfig({ profile: serverProfile });
 
 // Auto-migrate from legacy dirs on first server start (non-fatal)
 try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,11 +10,14 @@ import { syncMemoryFiles, syncSessionFiles, syncEmbeddings } from "./sync.js";
 import { searchMemory } from "./search.js";
 import { MEMORY_EXTENSIONS, hashText, buildExtraDirAliases } from "./internal.js";
 import { loadConfig, resolvedExtraDirs, migrateFromLegacyDirs, listProfiles } from "./config.js";
+import { setModelSpec } from "./embedding.js";
 
-// Parse --profile from process.argv (before MCP takes over stdio)
+// Parse --profile from process.argv or MEMORY_MCP_PROFILE env var
 const serverProfile = (() => {
   const idx = process.argv.indexOf("--profile");
-  return idx >= 0 && process.argv[idx + 1] ? process.argv[idx + 1] : undefined;
+  return (idx >= 0 && process.argv[idx + 1])
+    ? process.argv[idx + 1]
+    : (process.env.MEMORY_MCP_PROFILE || undefined);
 })();
 
 if (serverProfile) {
@@ -25,6 +28,7 @@ if (serverProfile) {
 }
 
 const config = loadConfig({ profile: serverProfile });
+setModelSpec(config.model);
 
 // Auto-migrate from legacy dirs on first server start (non-fatal)
 try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,13 +9,20 @@ import { openDatabase } from "./db.js";
 import { syncMemoryFiles, syncSessionFiles, syncEmbeddings } from "./sync.js";
 import { searchMemory } from "./search.js";
 import { MEMORY_EXTENSIONS, hashText, buildExtraDirAliases } from "./internal.js";
-import { loadConfig, resolvedExtraDirs, migrateFromLegacyDirs } from "./config.js";
+import { loadConfig, resolvedExtraDirs, migrateFromLegacyDirs, listProfiles } from "./config.js";
 
 // Parse --profile from process.argv (before MCP takes over stdio)
 const serverProfile = (() => {
   const idx = process.argv.indexOf("--profile");
   return idx >= 0 && process.argv[idx + 1] ? process.argv[idx + 1] : undefined;
 })();
+
+if (serverProfile) {
+  const known = listProfiles();
+  if (!known.includes(serverProfile)) {
+    console.error(`[memory-mcp] Warning: profile "${serverProfile}" not found in config. Using defaults.`);
+  }
+}
 
 const config = loadConfig({ profile: serverProfile });
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -90,7 +90,8 @@ function getHomeDir(): string {
 
 function buildProfile(target: "copilot" | "claude"): TargetProfile {
   const home = getHomeDir();
-  const workspaceDir = DEFAULTS.workspace; // shared: ~/.memory-mcp-workdir
+  const config = loadConfig();
+  const workspaceDir = config.workspace; // resolved from default profile
   if (target === "claude") {
     const claudeDir = path.join(home, ".claude");
     return {
@@ -423,17 +424,10 @@ function handleConfig(args: string[]): void {
       (partial as Record<string, unknown>)[key] = value;
     }
 
-    if (profileName) {
-      saveProfileConfig(profileName, partial);
-      console.log(`✓ [${profileName}] ${key} = ${JSON.stringify(partial[key])}`);
-    } else {
-      // Save to top-level (shared across profiles)
-      const filePath = configFilePath();
-      const existing = readConfigFile(filePath);
-      Object.assign(existing, partial);
-      saveConfigFile(existing, filePath);
-      console.log(`✓ ${key} = ${JSON.stringify(partial[key])}`);
-    }
+    // Save to the specified profile, or the default profile if not specified
+    const targetProfile = profileName ?? getDefaultProfile();
+    saveProfileConfig(targetProfile, partial);
+    console.log(`✓ [${targetProfile}] ${key} = ${JSON.stringify(partial[key])}`);
     console.log(`  Saved to ${configFilePath()}`);
     return;
   }
@@ -496,6 +490,13 @@ Use --profile <name> with the server: node dist/server.js --profile <name>`);
 
   // --- setup ---
   console.log(`Setting up memory-mcp for ${profile.name}...\n`);
+
+  // Initialize config file with default profile if it doesn't exist
+  const cfgPath = configFilePath();
+  if (!fs.existsSync(cfgPath)) {
+    createProfile(DEFAULT_PROFILE);
+    console.log(`✓ Created config with "${DEFAULT_PROFILE}" profile at ${cfgPath}`);
+  }
 
   // Migrate from legacy dirs if this is a fresh workspace
   migrateFromLegacyDirs(profile.workspaceDir);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -7,7 +7,8 @@ import {
   loadConfig, readConfigFile, saveConfigFile, deleteConfigFile,
   configFilePath, DEFAULTS, migrateFromLegacyDirs,
   listProfiles, getDefaultProfile, createProfile, deleteProfile,
-  saveProfileConfig, setDefaultProfile, DEFAULT_PROFILE,
+  saveProfileConfig, setDefaultProfile, resetProfile,
+  DEFAULT_PROFILE, DEFAULT_WORKDIR, validateProfileName,
   type MemoryConfig, type MemoryConfigFile,
 } from "./config.js";
 
@@ -315,6 +316,10 @@ function handleConfig(args: string[]): void {
       if (!name) { console.error("Usage: memory-mcp config profile delete <name>"); process.exit(1); }
       if (deleteProfile(name)) {
         console.log(`✓ Profile "${name}" deleted.`);
+        const wsDir = path.join(DEFAULT_WORKDIR, name);
+        if (fs.existsSync(wsDir)) {
+          console.log(`  Note: Workspace directory retained at ${wsDir} — remove manually if no longer needed.`);
+        }
       } else {
         console.log(`  Profile "${name}" not found.`);
       }
@@ -348,9 +353,9 @@ function handleConfig(args: string[]): void {
 
   if (sub === "reset") {
     if (profileName) {
-      // Reset specific profile
-      if (deleteProfile(profileName)) {
-        console.log(`✓ Profile "${profileName}" deleted (reset).`);
+      // Reset profile config to empty (keeps the profile entry)
+      if (resetProfile(profileName)) {
+        console.log(`✓ Profile "${profileName}" reset to defaults.`);
       } else {
         console.log(`  Profile "${profileName}" not found.`);
       }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 import {
   loadConfig, readConfigFile, saveConfigFile, deleteConfigFile,
   configFilePath, DEFAULTS, migrateFromLegacyDirs,
+  listProfiles, getDefaultProfile, createProfile, deleteProfile,
+  saveProfileConfig, setDefaultProfile, DEFAULT_PROFILE,
   type MemoryConfig, type MemoryConfigFile,
 } from "./config.js";
 
@@ -274,13 +276,66 @@ const CONFIG_KEYS: (keyof MemoryConfig)[] = [
 ];
 
 function handleConfig(args: string[]): void {
-  const sub = args[0];
+  // Extract --profile flag from args
+  let profileName: string | undefined;
+  const filteredArgs: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--profile" && args[i + 1]) {
+      profileName = args[++i];
+    } else {
+      filteredArgs.push(args[i]!);
+    }
+  }
+  const sub = filteredArgs[0];
+
+  // Profile management subcommands
+  if (sub === "profile") {
+    const action = filteredArgs[1];
+    if (!action || action === "list") {
+      const profiles = listProfiles();
+      const defaultP = getDefaultProfile();
+      for (const p of profiles) {
+        console.log(p === defaultP ? `  ${p} (default)` : `  ${p}`);
+      }
+      return;
+    }
+    if (action === "create") {
+      const name = filteredArgs[2];
+      if (!name) { console.error("Usage: memory-mcp config profile create <name>"); process.exit(1); }
+      if (createProfile(name)) {
+        console.log(`✓ Profile "${name}" created.`);
+      } else {
+        console.log(`  Profile "${name}" already exists.`);
+      }
+      return;
+    }
+    if (action === "delete") {
+      const name = filteredArgs[2];
+      if (!name) { console.error("Usage: memory-mcp config profile delete <name>"); process.exit(1); }
+      if (deleteProfile(name)) {
+        console.log(`✓ Profile "${name}" deleted.`);
+      } else {
+        console.log(`  Profile "${name}" not found.`);
+      }
+      return;
+    }
+    if (action === "default") {
+      const name = filteredArgs[2];
+      if (!name) { console.error("Usage: memory-mcp config profile default <name>"); process.exit(1); }
+      setDefaultProfile(name);
+      console.log(`✓ Default profile set to "${name}".`);
+      return;
+    }
+    console.error("Usage: memory-mcp config profile [list|create|delete|default] [name]");
+    process.exit(1);
+  }
 
   if (!sub || sub === "show") {
-    // Show merged config
-    const merged = loadConfig();
+    const merged = loadConfig({ profile: profileName });
     const filePath = configFilePath();
-    console.log(`Config file: ${filePath}\n`);
+    const label = profileName ?? getDefaultProfile();
+    console.log(`Config file: ${filePath}`);
+    console.log(`Profile: ${label}\n`);
     console.log(JSON.stringify(merged, null, 2));
     return;
   }
@@ -291,21 +346,30 @@ function handleConfig(args: string[]): void {
   }
 
   if (sub === "reset") {
-    const filePath = configFilePath();
-    if (deleteConfigFile(filePath)) {
-      console.log(`✓ Config file deleted: ${filePath}`);
-      console.log("  All settings reset to defaults.");
+    if (profileName) {
+      // Reset specific profile
+      if (deleteProfile(profileName)) {
+        console.log(`✓ Profile "${profileName}" deleted (reset).`);
+      } else {
+        console.log(`  Profile "${profileName}" not found.`);
+      }
     } else {
-      console.log("  No config file found — already using defaults.");
+      const filePath = configFilePath();
+      if (deleteConfigFile(filePath)) {
+        console.log(`✓ Config file deleted: ${filePath}`);
+        console.log("  All profiles and settings reset to defaults.");
+      } else {
+        console.log("  No config file found — already using defaults.");
+      }
     }
     return;
   }
 
   if (sub === "set") {
-    const key = args[1] as keyof MemoryConfig | undefined;
-    const value = args[2];
+    const key = filteredArgs[1] as keyof MemoryConfig | undefined;
+    const value = filteredArgs[2];
     if (!key || value === undefined) {
-      console.error("Usage: memory-mcp config set <key> <value>");
+      console.error("Usage: memory-mcp config [--profile <name>] set <key> <value>");
       console.error(`Valid keys: ${CONFIG_KEYS.join(", ")}`);
       process.exit(1);
     }
@@ -315,16 +379,14 @@ function handleConfig(args: string[]): void {
       process.exit(1);
     }
 
-    // Read existing file config (not merged)
-    const filePath = configFilePath();
-    const existing = readConfigFile(filePath);
+    // Build the partial config to save
+    const partial: MemoryConfigFile = {};
 
     // Parse and validate value
     if (key === "extraDirs") {
-      existing.extraDirs = value
+      partial.extraDirs = value
         .split(",").map((d) => d.trim()).filter(Boolean).map((d) => path.resolve(d));
     } else if (key === "sessionDirs") {
-      // JSON input: '[{"dir":"/path","kind":"copilot"}]'
       try {
         const parsed = JSON.parse(value);
         if (!Array.isArray(parsed)) throw new Error("must be an array");
@@ -333,7 +395,7 @@ function handleConfig(args: string[]): void {
             throw new Error(`each entry needs {dir, kind: "copilot"|"claude"}`);
           }
         }
-        existing.sessionDirs = parsed;
+        partial.sessionDirs = parsed;
       } catch (err) {
         console.error(`sessionDirs must be valid JSON array, e.g. '[{"dir":"/path","kind":"copilot"}]'`);
         console.error(`Error: ${err instanceof Error ? err.message : err}`);
@@ -345,7 +407,6 @@ function handleConfig(args: string[]): void {
         console.error(`${key} must be a number, got "${value}"`);
         process.exit(1);
       }
-      // Range validation
       const ranges: Record<string, [number, number]> = {
         chunkSize: [64, 4096],
         tokenMax: [100, 16384],
@@ -357,20 +418,28 @@ function handleConfig(args: string[]): void {
         console.error(`${key} must be between ${min} and ${max === Infinity ? "∞" : max}, got ${n}`);
         process.exit(1);
       }
-      existing[key] = n;
+      partial[key] = n;
     } else {
-      // string fields: workspace, dbPath, model
-      (existing as Record<string, unknown>)[key] = value;
+      (partial as Record<string, unknown>)[key] = value;
     }
 
-    saveConfigFile(existing, filePath);
-    console.log(`✓ ${key} = ${JSON.stringify(existing[key])}`);
-    console.log(`  Saved to ${filePath}`);
+    if (profileName) {
+      saveProfileConfig(profileName, partial);
+      console.log(`✓ [${profileName}] ${key} = ${JSON.stringify(partial[key])}`);
+    } else {
+      // Save to top-level (shared across profiles)
+      const filePath = configFilePath();
+      const existing = readConfigFile(filePath);
+      Object.assign(existing, partial);
+      saveConfigFile(existing, filePath);
+      console.log(`✓ ${key} = ${JSON.stringify(partial[key])}`);
+    }
+    console.log(`  Saved to ${configFilePath()}`);
     return;
   }
 
   console.error(`Unknown config subcommand: ${sub}`);
-  console.error("Usage: memory-mcp config [show|set|reset|path]");
+  console.error("Usage: memory-mcp config [show|set|reset|path|profile]");
   process.exit(1);
 }
 
@@ -388,17 +457,22 @@ function main() {
     console.log(`memory-mcp — Local memory management for AI coding assistants
 
 Usage:
-  memory-mcp setup [--claude]       Configure MCP server for Copilot CLI (or Claude Code)
-  memory-mcp uninstall [--claude]   Remove memory MCP configuration
-  memory-mcp config [show]          Show current merged configuration
-  memory-mcp config set <key> <val> Set a config value
-  memory-mcp config reset           Reset config to defaults
-  memory-mcp config path            Show config file path
+  memory-mcp setup [--claude]                  Configure MCP server
+  memory-mcp uninstall [--claude]              Remove memory MCP configuration
+  memory-mcp config [--profile <name>] [show]  Show config (optionally for a profile)
+  memory-mcp config [--profile <name>] set <key> <val>  Set a config value
+  memory-mcp config [--profile <name>] reset   Reset config/profile
+  memory-mcp config path                       Show config file path
+  memory-mcp config profile list               List all profiles
+  memory-mcp config profile create <name>      Create a new profile
+  memory-mcp config profile delete <name>      Delete a profile
+  memory-mcp config profile default <name>     Set the default profile
 
 Options:
   --claude    Target Claude Code CLI instead of GitHub Copilot CLI
 
-The MCP server itself is started automatically by the host CLI.`);
+The MCP server itself is started automatically by the host CLI.
+Use --profile <name> with the server: node dist/server.js --profile <name>`);
     process.exit(0);
   }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -328,8 +328,12 @@ function handleConfig(args: string[]): void {
     if (action === "default") {
       const name = filteredArgs[2];
       if (!name) { console.error("Usage: memory-mcp config profile default <name>"); process.exit(1); }
-      setDefaultProfile(name);
-      console.log(`✓ Default profile set to "${name}".`);
+      if (setDefaultProfile(name)) {
+        console.log(`✓ Default profile set to "${name}".`);
+      } else {
+        console.error(`Profile "${name}" not found. Create it first: memory-mcp config profile create ${name}`);
+        process.exit(1);
+      }
       return;
     }
     console.error("Usage: memory-mcp config profile [list|create|delete|default] [name]");


### PR DESCRIPTION
## Why

After PR #4 centralized config, all memories (coding, learning, project context) share one workspace and database. Different use cases pollute each other's search results. Need full isolation — separate DB, files, and config per use case.

## Design

**Profile isolation over scope filtering.** Scope/tag filtering still shares a single DB and vector index — noisy. Instead, each profile gets its own workspace directory (`~/.memory-mcp-workdir/<name>/`) with independent `memory.db`, `MEMORY.md`, and `memory/`. Zero cross-pollution.

**Backward compatible.** Legacy flat config (no `profiles` key) is treated as `default` profile. On first profile creation, `workspace` and `dbPath` are migrated into `profiles.default` to preserve custom paths.

## Changes

**config.ts** — Profile system core: `{ defaultProfile, profiles: { name: config } }` structure. `loadConfig()` accepts `{ profile, overrides, configPath }`. CRUD: create/delete/reset/setDefault/list. `validateProfileName()` blocks path traversal. `ensureProfilesSection()` handles legacy migration. workspace/dbPath not inherited from top-level in profile mode.

**setup.ts** — `config profile list/create/delete/default` subcommands. `--profile` flag for show/set/reset.

**server.ts** — `--profile` argv + `MEMORY_MCP_PROFILE` env var fallback. Profile existence warning.

**cli.ts** — `--profile` global flag. `--config` deprecation warning.

**embedding.ts** — `setModelSpec()` export so server/cli inject profile-specific model at startup.

**README.md** — Profile docs, config example, migration notes, breaking changes.

## 11 commits

1. Initial multi-profile implementation
2–9. Review fixes: profile name validation, legacy workspace/dbPath preservation, embedding profile propagation, DRY refactor, setDefaultProfile existence check, --config deprecation, deleteProfile disk warning
10. Fix legacy dbPath lost during flat→profile migration
11. README completeness update
