### PR TITLE
fix: use k= constraint for sqlite-vec KNN queries

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -144,9 +144,8 @@ export async function searchMemory(
           `SELECT v.id, v.distance, c.path, c.source, c.start_line, c.end_line, c.text
            FROM chunks_vec v
            JOIN chunks c ON c.id = v.id
-           WHERE embedding MATCH ?
-           ORDER BY distance
-           LIMIT ?`,
+           WHERE embedding MATCH ? AND k = ?
+           ORDER BY distance`,
         )
         .all(queryBuf, maxResults * 3) as Array<{
         id: string;


### PR DESCRIPTION
## Problem

Newer versions of sqlite-vec require `k = ?` in the WHERE clause for vec0 KNN queries instead of `LIMIT ?`. Error: `A LIMIT or 'k = ?' constraint is required on vec0 knn queries`. Vector search silently falls back to FTS-only.

## Fix

Replace `LIMIT ?` with `AND k = ?` in the vec KNN query in `search.ts`. The `k =` syntax is backward compatible with older sqlite-vec versions (tested on v0.1.7-alpha.2).

## Changes

- `src/search.ts`: 1 query, 2 lines changed