### PR TITLE
fix: improve embedding sync for weak machines without GPU

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -154,8 +154,9 @@ async function main(): Promise<void> {
       maxCount: config.sessionMax,
       sessionDirs: config.sessionDirs,
     });
-    // Best-effort embedding sync
-    try { await syncEmbeddings(db); } catch {}
+    // Fire off embedding sync (non-blocking — search proceeds immediately)
+    // Cross-process lock in syncEmbeddings ensures only one process embeds at a time.
+    const embeddingDone = syncEmbeddings(db).catch(() => {});
 
     if (command === "search") {
       if (!query) {
@@ -195,6 +196,9 @@ async function main(): Promise<void> {
     } else {
       throw new Error(`Unknown command: ${command}`);
     }
+
+    // Wait for embedding to finish before closing DB
+    await embeddingDone;
   } finally {
     db.close();
   }

--- a/src/search.ts
+++ b/src/search.ts
@@ -90,13 +90,16 @@ export async function searchMemory(
   const ftsOk = isFtsAvailable(db);
   let vecOk = isVecAvailable(db);
 
-  // Skip vector search if embedding coverage is too low (still syncing)
+  // Use vector search whenever any embeddings exist (progressive — no hard threshold)
+  let embeddingCoverage = 0;
   if (vecOk) {
     try {
       const total = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
       const embedded = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec`).get() as { c: number }).c;
-      if (total > 0 && embedded / total < 0.8) {
+      if (embedded === 0) {
         vecOk = false;
+      } else if (total > 0) {
+        embeddingCoverage = embedded / total;
       }
     } catch {}
   }
@@ -174,7 +177,10 @@ export async function searchMemory(
   // Hybrid merge or single-source
   let results: SearchResult[];
   if (ftsResults.length > 0 && vecResults.length > 0) {
-    results = mergeHybrid(ftsResults, vecResults, 0.5, 0.5);
+    // Dynamic weight: scale vector contribution by embedding coverage
+    const vecWeight = Math.min(0.5, embeddingCoverage);
+    const ftsWeight = 1 - vecWeight;
+    results = mergeHybrid(ftsResults, vecResults, ftsWeight, vecWeight);
   } else if (vecResults.length > 0) {
     results = vecResults;
   } else if (ftsResults.length > 0) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,7 @@ const dbPath = config.dbPath;
 let db: import("better-sqlite3").Database;
 let lastSyncAt = 0;
 let lastSessionSyncAt = 0;
+let embeddingSyncInProgress = false;
 const SYNC_COOLDOWN_MS = 5_000;
 const SESSION_SYNC_COOLDOWN_MS = 60_000;
 
@@ -72,10 +73,13 @@ async function ensureSynced(): Promise<void> {
       });
       lastSessionSyncAt = Date.now();
     }
-    // Async embedding sync — don't block on it
-    syncEmbeddings(db).catch((err) =>
-      console.error("[memory-mcp] embedding sync error:", err),
-    );
+    // Async embedding sync — don't block, skip if already running
+    if (!embeddingSyncInProgress) {
+      embeddingSyncInProgress = true;
+      syncEmbeddings(db)
+        .catch((err) => console.error("[memory-mcp] embedding sync error:", err))
+        .finally(() => { embeddingSyncInProgress = false; });
+    }
   } catch (err) {
     console.error("memory sync error:", err);
   }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -150,18 +150,22 @@ function indexFile(
       )
     : null;
 
-  const insertVec = oldVecs.size > 0
-    ? db.prepare(`INSERT OR REPLACE INTO chunks_vec (id, embedding) VALUES (?, ?)`)
-    : null;
+  const insertVec = db.prepare(`INSERT OR REPLACE INTO chunks_vec (id, embedding) VALUES (?, ?)`);
+  const findCache = db.prepare(`SELECT embedding FROM embedding_cache WHERE hash = ?`);
 
   const transaction = db.transaction(() => {
     for (const chunk of chunkData) {
       insertChunk.run(chunk.id, entry.path, source, chunk.startLine, chunk.endLine, chunk.hash, chunk.text, now);
       insertFts?.run(segmentText(chunk.text), chunk.id, entry.path, source, chunk.startLine, chunk.endLine);
-      // Re-insert embedding if content hash matches salvaged vec
+      // Re-insert embedding: prefer salvaged vec, fallback to embedding_cache
       const savedVec = oldVecs.get(chunk.hash);
-      if (savedVec && insertVec) {
-        insertVec.run(chunk.id, savedVec);
+      if (savedVec) {
+        try { insertVec.run(chunk.id, savedVec); } catch {}
+      } else {
+        const cached = findCache.get(chunk.hash) as { embedding: Buffer } | undefined;
+        if (cached) {
+          try { insertVec.run(chunk.id, cached.embedding); } catch {}
+        }
       }
     }
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -150,13 +150,16 @@ function indexFile(
       )
     : null;
 
-  const insertVec = db.prepare(`INSERT OR REPLACE INTO chunks_vec (id, embedding) VALUES (?, ?)`);
+  const insertVec = isVecAvailable(db)
+    ? db.prepare(`INSERT OR REPLACE INTO chunks_vec (id, embedding) VALUES (?, ?)`)
+    : null;
   const findCache = db.prepare(`SELECT embedding FROM embedding_cache WHERE hash = ?`);
 
   const transaction = db.transaction(() => {
     for (const chunk of chunkData) {
       insertChunk.run(chunk.id, entry.path, source, chunk.startLine, chunk.endLine, chunk.hash, chunk.text, now);
       insertFts?.run(segmentText(chunk.text), chunk.id, entry.path, source, chunk.startLine, chunk.endLine);
+      if (!insertVec) continue;
       // Re-insert embedding: prefer salvaged vec, fallback to embedding_cache
       const savedVec = oldVecs.get(chunk.hash);
       if (savedVec) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -256,7 +256,7 @@ export async function syncSessionFiles(
  * Uses BEGIN IMMEDIATE for atomic acquisition and PID liveness check.
  * Steals lock from dead processes or alive-but-stuck processes (>2h).
  */
-const MAX_LOCK_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours — generous for weak machines
+const MAX_LOCK_AGE_MS = 1 * 60 * 60 * 1000; // 1 hour — generous for weak machines
 
 function tryAcquireEmbeddingLock(db: Database.Database): boolean {
   try {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -105,10 +105,21 @@ function indexFile(
   const filtered = chunks.filter((c) => c.text.trim().length > 0);
   const now = Date.now();
 
-  // Clear old data for this file (including vectors)
+  // Salvage existing embeddings before clearing (keyed by content hash)
+  const oldVecs = new Map<string, Buffer>();
   const oldChunkIds = db
     .prepare(`SELECT id FROM chunks WHERE path = ? AND source = ?`)
     .all(entry.path, source) as Array<{ id: string }>;
+  try {
+    for (const { id } of oldChunkIds) {
+      const row = db.prepare(
+        `SELECT c.hash, v.embedding FROM chunks c JOIN chunks_vec v ON v.id = c.id WHERE c.id = ?`,
+      ).get(id) as { hash: string; embedding: Buffer } | undefined;
+      if (row) oldVecs.set(row.hash, row.embedding);
+    }
+  } catch {}
+
+  // Clear old data for this file (including vectors)
   try {
     for (const { id } of oldChunkIds) {
       db.prepare(`DELETE FROM chunks_vec WHERE id = ?`).run(id);
@@ -139,10 +150,19 @@ function indexFile(
       )
     : null;
 
+  const insertVec = oldVecs.size > 0
+    ? db.prepare(`INSERT OR REPLACE INTO chunks_vec (id, embedding) VALUES (?, ?)`)
+    : null;
+
   const transaction = db.transaction(() => {
     for (const chunk of chunkData) {
       insertChunk.run(chunk.id, entry.path, source, chunk.startLine, chunk.endLine, chunk.hash, chunk.text, now);
       insertFts?.run(segmentText(chunk.text), chunk.id, entry.path, source, chunk.startLine, chunk.endLine);
+      // Re-insert embedding if content hash matches salvaged vec
+      const savedVec = oldVecs.get(chunk.hash);
+      if (savedVec && insertVec) {
+        insertVec.run(chunk.id, savedVec);
+      }
     }
 
     // Upsert file record
@@ -225,87 +245,166 @@ export async function syncSessionFiles(
 }
 
 /**
+ * Cross-process embedding lock using the meta table.
+ * Uses BEGIN IMMEDIATE for atomic acquisition and PID liveness check.
+ * Steals lock from dead processes or alive-but-stuck processes (>2h).
+ */
+const MAX_LOCK_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours — generous for weak machines
+
+function tryAcquireEmbeddingLock(db: Database.Database): boolean {
+  try {
+    // BEGIN IMMEDIATE acquires a write lock immediately, preventing races
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      const row = db.prepare(`SELECT value FROM meta WHERE key = 'embedding_lock'`).get() as
+        | { value: string }
+        | undefined;
+      if (row) {
+        const lock = JSON.parse(row.value) as { pid: number; startedAt: number };
+        if (isPidAlive(lock.pid) && Date.now() - lock.startedAt < MAX_LOCK_AGE_MS) {
+          db.exec("ROLLBACK");
+          return false;
+        }
+        // Lock holder is dead or stuck too long — steal it
+      }
+      db.prepare(`INSERT OR REPLACE INTO meta (key, value) VALUES ('embedding_lock', ?)`).run(
+        JSON.stringify({ pid: process.pid, startedAt: Date.now() }),
+      );
+      db.exec("COMMIT");
+      return true;
+    } catch {
+      db.exec("ROLLBACK");
+      return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
+/** Check if a PID is alive. Distinguishes ESRCH (dead) from EPERM (alive). */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    // EPERM = process exists but we lack permission → alive
+    if (err && typeof err === "object" && "code" in err && err.code === "EPERM") return true;
+    return false; // ESRCH = no such process → dead
+  }
+}
+
+function releaseEmbeddingLock(db: Database.Database): void {
+  try {
+    const row = db.prepare(`SELECT value FROM meta WHERE key = 'embedding_lock'`).get() as
+      | { value: string }
+      | undefined;
+    if (row) {
+      const lock = JSON.parse(row.value) as { pid: number };
+      if (lock.pid === process.pid) {
+        db.prepare(`DELETE FROM meta WHERE key = 'embedding_lock'`).run();
+      }
+    }
+  } catch {}
+}
+
+/**
  * Compute and store embeddings for chunks that don't have them yet.
- * Runs after the main sync to avoid blocking startup.
+ * Uses a cross-process PID lock so only one process embeds at a time.
  */
 export async function syncEmbeddings(db: Database.Database): Promise<number> {
   const vecOk = isVecAvailable(db);
   if (!vecOk) return 0;
 
-  let totalEmbedded = 0;
-  const findMissing = db.prepare(
-    `SELECT c.id, c.hash, c.text FROM chunks c
-     WHERE NOT EXISTS (SELECT 1 FROM chunks_vec v WHERE v.id = c.id)
-     LIMIT 100`,
-  );
-  const findCache = db.prepare(`SELECT embedding FROM embedding_cache WHERE hash = ?`);
-  const insertVec = db.prepare(`INSERT OR REPLACE INTO chunks_vec (id, embedding) VALUES (?, ?)`);
-  const insertCache = db.prepare(
-    `INSERT OR REPLACE INTO embedding_cache (hash, embedding, updated_at) VALUES (?, ?, ?)`,
-  );
+  if (!tryAcquireEmbeddingLock(db)) return 0;
 
-  while (true) {
-    const missing = findMissing.all() as Array<{ id: string; hash: string; text: string }>;
-    if (missing.length === 0) break;
-
-    // Check embedding cache for already-computed hashes
-    const cached = new Map<string, Buffer>();
-    const uncached: Array<{ index: number; id: string; hash: string; text: string }> = [];
-
-    for (let i = 0; i < missing.length; i++) {
-      const row = missing[i]!;
-      const hit = findCache.get(row.hash) as { embedding: Buffer } | undefined;
-      if (hit) {
-        cached.set(row.id, hit.embedding);
-      } else {
-        uncached.push({ index: i, ...row });
-      }
-    }
-
-    // Embed uncached texts in batch
-    let newEmbeddings: number[][] = [];
-    let embedFailed = false;
-    if (uncached.length > 0) {
-      try {
-        newEmbeddings = await embedBatch(uncached.map((u) => u.text));
-      } catch (err) {
-        console.error("[memory-mcp] embedding failed:", err);
-        embedFailed = true;
-      }
-    }
-
-    // Store all embeddings (including cached hits even if embed failed)
-    const now = Date.now();
-    const tx = db.transaction(() => {
-      for (const [id, buf] of cached) {
-        insertVec.run(id, buf);
-      }
-      for (let i = 0; i < uncached.length; i++) {
-        const item = uncached[i]!;
-        const vec = newEmbeddings[i];
-        if (!vec || vec.length === 0) continue;
-        const buf = vectorToBuffer(vec);
-        insertVec.run(item.id, buf);
-        insertCache.run(item.hash, buf, now);
-      }
-    });
-    tx();
-
-    totalEmbedded += cached.size + newEmbeddings.length;
-
-    if (embedFailed) {
-      const remaining = (db.prepare(
-        `SELECT COUNT(*) as c FROM chunks c WHERE NOT EXISTS (SELECT 1 FROM chunks_vec v WHERE v.id = c.id)`,
-      ).get() as { c: number }).c;
-      console.error(`[memory-mcp] embedding stopped early; ${remaining} chunk(s) still need embedding`);
-      break;
-    }
-  }
-
-  // Clean stale embedding cache entries
   try {
-    db.prepare(`DELETE FROM embedding_cache WHERE NOT EXISTS (SELECT 1 FROM chunks WHERE chunks.hash = embedding_cache.hash)`).run();
-  } catch {}
+    const totalChunks = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
+    let totalEmbedded = 0;
+    let batchCount = 0;
+    const findMissing = db.prepare(
+      `SELECT c.id, c.hash, c.text FROM chunks c
+       WHERE NOT EXISTS (SELECT 1 FROM chunks_vec v WHERE v.id = c.id)
+       LIMIT 100`,
+    );
+    const findCache = db.prepare(`SELECT embedding FROM embedding_cache WHERE hash = ?`);
+    const insertVec = db.prepare(`INSERT OR REPLACE INTO chunks_vec (id, embedding) VALUES (?, ?)`);
+    const insertCache = db.prepare(
+      `INSERT OR REPLACE INTO embedding_cache (hash, embedding, updated_at) VALUES (?, ?, ?)`,
+    );
 
-  return totalEmbedded;
+    while (true) {
+      const missing = findMissing.all() as Array<{ id: string; hash: string; text: string }>;
+      if (missing.length === 0) break;
+
+      // Check embedding cache for already-computed hashes
+      const cached = new Map<string, Buffer>();
+      const uncached: Array<{ index: number; id: string; hash: string; text: string }> = [];
+
+      for (let i = 0; i < missing.length; i++) {
+        const row = missing[i]!;
+        const hit = findCache.get(row.hash) as { embedding: Buffer } | undefined;
+        if (hit) {
+          cached.set(row.id, hit.embedding);
+        } else {
+          uncached.push({ index: i, ...row });
+        }
+      }
+
+      // Embed uncached texts in batch
+      let newEmbeddings: number[][] = [];
+      let embedFailed = false;
+      if (uncached.length > 0) {
+        try {
+          newEmbeddings = await embedBatch(uncached.map((u) => u.text));
+        } catch (err) {
+          console.error("[memory-mcp] embedding failed:", err);
+          embedFailed = true;
+        }
+      }
+
+      // Store all embeddings (including cached hits even if embed failed)
+      const now = Date.now();
+      const tx = db.transaction(() => {
+        for (const [id, buf] of cached) {
+          insertVec.run(id, buf);
+        }
+        for (let i = 0; i < uncached.length; i++) {
+          const item = uncached[i]!;
+          const vec = newEmbeddings[i];
+          if (!vec || vec.length === 0) continue;
+          const buf = vectorToBuffer(vec);
+          insertVec.run(item.id, buf);
+          insertCache.run(item.hash, buf, now);
+        }
+      });
+      tx();
+
+      totalEmbedded += cached.size + newEmbeddings.length;
+      batchCount++;
+
+      // Progress logging — throttle to every 5th batch to reduce COUNT(*) overhead
+      if (totalChunks > 0 && batchCount % 5 === 0) {
+        const done = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec`).get() as { c: number }).c;
+        const pct = ((done / totalChunks) * 100).toFixed(1);
+        console.error(`[memory-mcp] embedding progress: ${done}/${totalChunks} (${pct}%)`);
+      }
+
+      if (embedFailed) {
+        const remaining = (db.prepare(
+          `SELECT COUNT(*) as c FROM chunks c WHERE NOT EXISTS (SELECT 1 FROM chunks_vec v WHERE v.id = c.id)`,
+        ).get() as { c: number }).c;
+        console.error(`[memory-mcp] embedding stopped early; ${remaining} chunk(s) still need embedding`);
+        break;
+      }
+    }
+
+    // Clean stale embedding cache entries
+    try {
+      db.prepare(`DELETE FROM embedding_cache WHERE NOT EXISTS (SELECT 1 FROM chunks WHERE chunks.hash = embedding_cache.hash)`).run();
+    } catch {}
+
+    return totalEmbedded;
+  } finally {
+    releaseEmbeddingLock(db);
+  }
 }


### PR DESCRIPTION
## Problem

Embedding generation can take 6+ hours on weak machines (no GPU). Original design had:

1. **CLI blocks search** on `await syncEmbeddings(db)`
2. **Server spawns duplicate** embedding tasks every 5s (no concurrency guard)
3. **80% coverage threshold** wastes partially-generated embeddings
4. **No cross-process coordination** between CLI and Server
5. **chunks_vec perpetually empty** — `indexFile()` deletes all vec entries on re-index, but embedding is too slow to regenerate before the next re-index cycle; `embedding_cache` accumulates (keyed by content hash) but `chunks_vec` stays at 0 (keyed by chunk ID which changes when line offsets shift)

## Changes

### Vec salvage in `indexFile()` (`sync.ts`)
- Before clearing old chunks, collect `{contentHash → embedding}` map from existing `chunks_vec`
- After inserting new chunks, re-insert embeddings for chunks whose content hash matches
- Line offsets may shift but if text is identical, the embedding is reused with the new chunk ID
- Zero overhead on first index (no old vecs to salvage)

### Cross-process PID lock (`sync.ts`)
- Atomic lock via `BEGIN IMMEDIATE` + `meta` table
- `isPidAlive()` distinguishes ESRCH (dead) from EPERM (alive)
- 2-hour stale-lock timeout for hung processes

### CLI (`cli.ts`)
- Fire-and-forget embedding (search proceeds immediately)
- Awaits embedding completion before exit (safe DB close)
- Skips if another process holds the lock

### Server (`server.ts`)
- In-process `embeddingSyncInProgress` guard (avoids redundant DB queries)
- Cross-process PID lock coordination with CLI

### Search (`search.ts`)
- Progressive vector search: use whatever embeddings exist (`embedded > 0`)
- Dynamic hybrid weight: `vecWeight = min(0.5, coverage)` to prevent low-coverage bias
- FTS/LIKE fallback when no embeddings available

### Progress logging (`sync.ts`)
- Logs every 5th batch: `embedding progress: 200/2000 (10%)`

## Concurrency matrix

| Scenario | Behavior |
|----------|----------|
| CLI search, no embeddings | FTS search + starts embedding in background |
| CLI embedding running, 2nd CLI | 2nd CLI searches immediately, skips embedding |
| CLI embedding running, server starts | Server searches normally, skips embedding, takes over after CLI exits |
| Server embedding running, CLI search | CLI searches normally, skips embedding |
| Process hung >2h holding lock | Lock stolen by next process |

WAL mode ensures embedding writes never block search reads.