### PR TITLE
fix: clean up orphan embeddings and fix embeddedChunks count

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -195,7 +195,9 @@ async function main(): Promise<void> {
       const sessionFileCount = (db.prepare(`SELECT COUNT(*) as c FROM files WHERE source = 'sessions'`).get() as { c: number }).c;
       const chunkCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
       let vecCount = 0;
-      try { vecCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec`).get() as { c: number }).c; } catch {}
+      try {
+        vecCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec v WHERE EXISTS (SELECT 1 FROM chunks c WHERE c.id = v.id)`).get() as { c: number }).c;
+      } catch {}
       let cacheCount = 0;
       try { cacheCount = (db.prepare(`SELECT COUNT(*) as c FROM embedding_cache`).get() as { c: number }).c; } catch {}
       console.log(JSON.stringify({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@
  */
 
 import path from "node:path";
-import { openDatabase } from "./db.js";
+import { countValidEmbeddings, openDatabase } from "./db.js";
 import { syncMemoryFiles, syncSessionFiles, syncEmbeddings } from "./sync.js";
 import { searchMemory } from "./search.js";
 import { loadConfig, resolvedExtraDirs, type MemoryConfigFile } from "./config.js";
@@ -194,10 +194,7 @@ async function main(): Promise<void> {
       const memoryFileCount = (db.prepare(`SELECT COUNT(*) as c FROM files WHERE source = 'memory'`).get() as { c: number }).c;
       const sessionFileCount = (db.prepare(`SELECT COUNT(*) as c FROM files WHERE source = 'sessions'`).get() as { c: number }).c;
       const chunkCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
-      let vecCount = 0;
-      try {
-        vecCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec v WHERE EXISTS (SELECT 1 FROM chunks c WHERE c.id = v.id)`).get() as { c: number }).c;
-      } catch {}
+      const vecCount = countValidEmbeddings(db);
       let cacheCount = 0;
       try { cacheCount = (db.prepare(`SELECT COUNT(*) as c FROM embedding_cache`).get() as { c: number }).c; } catch {}
       console.log(JSON.stringify({

--- a/src/db.ts
+++ b/src/db.ts
@@ -248,3 +248,13 @@ export function isVecAvailable(db: Database.Database): boolean {
     return false;
   }
 }
+
+export function countValidEmbeddings(db: Database.Database): number {
+  try {
+    return (db.prepare(
+      `SELECT COUNT(*) as c FROM chunks_vec v WHERE EXISTS (SELECT 1 FROM chunks c WHERE c.id = v.id)`,
+    ).get() as { c: number }).c;
+  } catch {
+    return 0;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import path from "node:path";
 import fs from "node:fs";
-import { openDatabase } from "./db.js";
+import { countValidEmbeddings, openDatabase } from "./db.js";
 import { syncMemoryFiles, syncSessionFiles } from "./sync.js";
 import { searchMemory } from "./search.js";
 import type { EmbedFn } from "./search.js";
@@ -298,10 +298,7 @@ server.tool(
     const memoryFileCount = (db.prepare(`SELECT COUNT(*) as c FROM files WHERE source = 'memory'`).get() as { c: number }).c;
     const sessionFileCount = (db.prepare(`SELECT COUNT(*) as c FROM files WHERE source = 'sessions'`).get() as { c: number }).c;
     const chunkCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
-    let vecCount = 0;
-    try {
-      vecCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec v WHERE EXISTS (SELECT 1 FROM chunks c WHERE c.id = v.id)`).get() as { c: number }).c;
-    } catch {}
+    const vecCount = countValidEmbeddings(db);
     let cacheCount = 0;
     try {
       cacheCount = (db.prepare(`SELECT COUNT(*) as c FROM embedding_cache`).get() as { c: number }).c;

--- a/src/server.ts
+++ b/src/server.ts
@@ -300,7 +300,7 @@ server.tool(
     const chunkCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
     let vecCount = 0;
     try {
-      vecCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec`).get() as { c: number }).c;
+      vecCount = (db.prepare(`SELECT COUNT(*) as c FROM chunks_vec v WHERE EXISTS (SELECT 1 FROM chunks c WHERE c.id = v.id)`).get() as { c: number }).c;
     } catch {}
     let cacheCount = 0;
     try {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -128,6 +128,10 @@ export async function syncMemoryFiles(
       // sqlite-vec may not support IN — fall back to per-row delete
       try { for (const c of chunkIds) db.prepare(`DELETE FROM chunks_vec WHERE id = ?`).run(c.id); } catch {}
     }
+    // If vec deletes still fail here, orphan embeddings remain until the next
+    // syncEmbeddings() pass, which runs a global NOT EXISTS sweep. That's
+    // acceptable because search joins chunks_vec back to chunks by id, so stale
+    // vec rows are ignored until then.
     deleted++;
   }
 
@@ -317,6 +321,10 @@ export async function syncSessionFiles(
     } catch {
       try { for (const c of chunkIds) db.prepare(`DELETE FROM chunks_vec WHERE id = ?`).run(c.id); } catch {}
     }
+    // If vec deletes still fail here, orphan embeddings remain until the next
+    // syncEmbeddings() pass, which runs a global NOT EXISTS sweep. That's
+    // acceptable because search joins chunks_vec back to chunks by id, so stale
+    // vec rows are ignored until then.
     deleted++;
   }
 
@@ -398,7 +406,8 @@ export async function syncEmbeddings(db: Database.Database): Promise<number> {
 
   try {
     const orphanCount = db.prepare(
-      `DELETE FROM chunks_vec WHERE id NOT IN (SELECT id FROM chunks)`,
+      `DELETE FROM chunks_vec
+       WHERE NOT EXISTS (SELECT 1 FROM chunks WHERE chunks.id = chunks_vec.id)`,
     ).run();
     if (orphanCount.changes > 0) {
       console.error(`[memory-mcp] cleaned up ${orphanCount.changes} orphan embedding(s)`);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -397,6 +397,13 @@ export async function syncEmbeddings(db: Database.Database): Promise<number> {
   if (!tryAcquireEmbeddingLock(db)) return 0;
 
   try {
+    const orphanCount = db.prepare(
+      `DELETE FROM chunks_vec WHERE id NOT IN (SELECT id FROM chunks)`,
+    ).run();
+    if (orphanCount.changes > 0) {
+      console.error(`[memory-mcp] cleaned up ${orphanCount.changes} orphan embedding(s)`);
+    }
+
     const totalChunks = (db.prepare(`SELECT COUNT(*) as c FROM chunks`).get() as { c: number }).c;
     let totalEmbedded = 0;
     let batchCount = 0;


### PR DESCRIPTION
## Problem

`embeddedChunks` could drift above `chunks` because `chunks_vec` retained orphan rows after chunk deletions. That caused status output to overcount embeddings and let stale vector entries accumulate until an embedding sync happened.

## Fix

- clean up orphan `chunks_vec` rows at the start of `syncEmbeddings`
- update `embeddedChunks` stats in both CLI and server status paths to count only embeddings that still have a matching chunk

## Validation

- `npm run build` ✅
- Before cleanup: `chunks=8265`, raw `chunks_vec` rows=`8365`
- Triggered `search "test" --profile knowledge --max-results 1`
  - observed log: `cleaned up 100 orphan embedding(s)`
- After cleanup: `chunks=8265`, raw `chunks_vec` rows=`8265`, `embeddedChunks=8265`